### PR TITLE
Custom provider: Properly handle relative paths

### DIFF
--- a/src/openvpn.rs
+++ b/src/openvpn.rs
@@ -41,11 +41,13 @@ impl OpenVpn {
             File::create(&log_file_str)?;
         }
 
+        let config_file_path = config_file.canonicalize().context("Invalid path given")?;
+
         info!("Launching OpenVPN...");
         let mut command_vec = (&[
             "openvpn",
             "--config",
-            config_file.as_os_str().to_str().unwrap(),
+            config_file_path.to_str().unwrap(),
             "--machine-readable-output",
             "--log",
             log_file_str.as_str(),
@@ -59,7 +61,7 @@ impl OpenVpn {
 
         let remotes = get_remotes_from_config(&config_file)?;
         debug!("Found remotes: {:?}", &remotes);
-        let working_dir = PathBuf::from(config_file.as_path().parent().unwrap());
+        let working_dir = PathBuf::from(config_file_path.parent().unwrap());
 
         handle = netns
             .exec_no_block(&command_vec, None, true, Some(working_dir))


### PR DESCRIPTION
Fixes #31.

Previously, when passing a relative path not proceded by `.` or `..` to `--custom`, it would fail with `No such file or directory`, since the working directory was not properly resolved.
This canonicalizes all relative paths first, turning them into absolute paths. This means that the working directory can always be resolved, and avoids all the issues with `parent()` mentioned in rust-lang/rust#36861.

The path to the config file is also canonicalized, since this enables using config files in different directories.
For example, previously for `--config ./test/foo.conf`, openvpn would be executed in the `./test/` directory, but passed `./test/foo.conf`, which made openvpn fail/hang because the file did not exist.
Now,  openvpn is executed in `/absolute/path/test/`, and passed `/absolute/path/test/foo.conf`.

This should not have an effect on other providers or absolute paths, as canonicalize will return an absolute path again (with symbolic links resolved).