### PR TITLE
Handle SIGINT gracefully

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ zip = "0.5"
 maplit = "1"
 webbrowser = "0.5"
 basic_tcp_proxy = "0.2"
-ctrlc = "3"
+signal-hook = "0.2"
 
 [package.metadata.rpm]
 package = "vopono"


### PR DESCRIPTION
When executing an interactive shell (such as `python` or similar), it is commonly necessary to communicate with the program using CTRL+C (for example, to terminate a long running action within it). Additionally, some long-running actions (such as `ping`) expect to be terminated using CTRL-C.

However, when running inside vopono, this kills vopono as well, thus not running any cleanup and taking the shell with it.

This PR catches all SIGINT signals during `exec` (they are automatically sent to the application as well, since it is in the same process group). This allows to child to respond to the signal as expected (handling in case of `python`, terminating in case of `ping`) and ensures graceful shutdown as vopono only exits after the child has exited.