### PR TITLE
Add NordVPN as provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.6.4"
+version = "0.6.6"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,7 @@ mod azirevpn;
 mod ivpn;
 mod mozilla;
 mod mullvad;
+mod nordvpn;
 mod pia;
 mod protonvpn;
 mod tigervpn;
@@ -37,6 +38,7 @@ pub enum VpnProvider {
     MozillaVPN,
     AzireVPN,
     IVPN,
+    NordVPN,
     Custom,
 }
 }
@@ -52,6 +54,7 @@ impl VpnProvider {
             Self::MozillaVPN => Box::new(mozilla::MozillaVPN {}),
             Self::AzireVPN => Box::new(azirevpn::AzireVPN {}),
             Self::IVPN => Box::new(ivpn::IVPN {}),
+            Self::NordVPN => Box::new(nordvpn::NordVPN {}),
             Self::Custom => unimplemented!("Custom provider uses separate logic"),
         }
     }
@@ -64,6 +67,7 @@ impl VpnProvider {
             Self::ProtonVPN => Ok(Box::new(protonvpn::ProtonVPN {})),
             Self::AzireVPN => Ok(Box::new(azirevpn::AzireVPN {})),
             Self::IVPN => Ok(Box::new(ivpn::IVPN {})),
+            Self::NordVPN => Ok(Box::new(nordvpn::NordVPN {})),
             Self::MozillaVPN => Err(anyhow!("MozillaVPN only supports Wireguard!")),
             Self::Custom => Err(anyhow!("Custom provider uses separate logic")),
         }

--- a/src/providers/nordvpn/mod.rs
+++ b/src/providers/nordvpn/mod.rs
@@ -1,0 +1,16 @@
+mod openvpn;
+
+use super::{ConfigurationChoice, OpenVpnProvider, Provider};
+use crate::vpn::Protocol;
+
+pub struct NordVPN {}
+
+impl Provider for NordVPN {
+    fn alias(&self) -> String {
+        "nordvpn".to_string()
+    }
+
+    fn default_protocol(&self) -> Protocol {
+        Protocol::OpenVpn
+    }
+}

--- a/src/providers/nordvpn/openvpn.rs
+++ b/src/providers/nordvpn/openvpn.rs
@@ -152,19 +152,11 @@ impl ConfigType {
     }
 
     fn is_onion(&self) -> bool {
-        match self {
-            Self::OnionTcp => true,
-            Self::OnionUdp => true,
-            _ => false,
-        }
+        matches!(self, Self::OnionTcp | Self::OnionUdp)
     }
 
     fn is_double(&self) -> bool {
-        match self {
-            Self::DoubleTcp => true,
-            Self::DoubleUdp => true,
-            _ => false,
-        }
+        matches!(self, Self::DoubleTcp | Self::DoubleUdp)
     }
 }
 

--- a/src/providers/nordvpn/openvpn.rs
+++ b/src/providers/nordvpn/openvpn.rs
@@ -1,0 +1,209 @@
+use super::NordVPN;
+use super::{ConfigurationChoice, OpenVpnProvider};
+use crate::util::delete_all_files_in_dir;
+use crate::vpn::OpenVpnProtocol;
+use dialoguer::{Input, Password};
+use log::debug;
+use regex::Regex;
+use std::fmt::Display;
+use std::fs::create_dir_all;
+use std::fs::File;
+use std::io::{Cursor, Read, Write};
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+use zip::ZipArchive;
+
+impl OpenVpnProvider for NordVPN {
+    fn provider_dns(&self) -> Option<Vec<IpAddr>> {
+        Some(vec![
+            IpAddr::V4(Ipv4Addr::new(103, 86, 96, 100)),
+            IpAddr::V4(Ipv4Addr::new(103, 86, 99, 100)),
+        ])
+    }
+
+    fn prompt_for_auth(&self) -> anyhow::Result<(String, String)> {
+        let username = Input::<String>::new()
+            .with_prompt("NordVPN username")
+            .interact()?;
+
+        let password = Password::new()
+            .with_prompt("Password")
+            .with_confirmation("Confirm password", "Passwords did not match")
+            .interact()?;
+        Ok((username, password))
+    }
+
+    fn auth_file_path(&self) -> anyhow::Result<PathBuf> {
+        Ok(self.openvpn_dir()?.join("auth.txt"))
+    }
+
+    fn create_openvpn_config(&self) -> anyhow::Result<()> {
+        let openvpn_dir = self.openvpn_dir()?;
+        let country_map = crate::util::country_map::code_to_country_map();
+        create_dir_all(&openvpn_dir)?;
+        delete_all_files_in_dir(&openvpn_dir)?;
+        let url = "https://downloads.nordcdn.com/configs/archives/servers/ovpn.zip";
+        let config_choice = ConfigType::choose_one()?;
+        let zipfile = reqwest::blocking::get(url)?;
+        let mut zip = ZipArchive::new(Cursor::new(zipfile.bytes()?))?;
+        let protocol_dir = match config_choice.get_protocol() {
+            OpenVpnProtocol::TCP => "ovpn_tcp",
+            OpenVpnProtocol::UDP => "ovpn_udp",
+        };
+        let server_regex = Regex::new(r"([a-z]+)(?:-(onion|[a-z]+))?([0-9]+)").unwrap();
+        for i in 0..zip.len() {
+            let mut file_contents: Vec<u8> = Vec::with_capacity(2048);
+            let mut file = zip.by_index(i).unwrap();
+
+            // TODO: sanitized_name is now deprecated but there is not a simple alternative
+            #[allow(deprecated)]
+            if !file.sanitized_name().starts_with(protocol_dir) {
+                continue;
+            }
+            file.read_to_end(&mut file_contents)?;
+
+            #[allow(deprecated)]
+            let filename = if let Some("ovpn") = file
+                .sanitized_name()
+                .extension()
+                .map(|x| x.to_str().expect("Could not convert OsStr"))
+            {
+                let fname = file.name();
+                let server_name = fname.to_lowercase().replace(' ', "_");
+                let server_name = server_name.split('.').next().unwrap();
+
+                if let Some(cap) = server_regex.captures(&server_name) {
+                    // check whether the server is a special config type
+                    // or not, and discard ones not in line with user's
+                    // selection
+                    if let Some(config_type) = cap.get(2) {
+                        if (config_type.as_str() == "onion" && !config_choice.is_onion())
+                            || !config_choice.is_double()
+                        {
+                            continue;
+                        }
+                    } else if config_choice.is_onion() || config_choice.is_double() {
+                        continue;
+                    }
+
+                    if let Some(code) = cap.get(1) {
+                        let country = country_map.get(code.as_str());
+                        if country.is_none() {
+                            debug!("Could not map country code to name: {}", code.as_str());
+                            file.name().to_string()
+                        } else {
+                            let server_name = server_name.replace("-", "_");
+                            format!("{}-{}.ovpn", country.unwrap(), server_name)
+                        }
+                    } else {
+                        debug!(
+                            "Filename did not match established pattern: {}",
+                            file.name().to_string()
+                        );
+                        file.name().to_string()
+                    }
+                } else {
+                    debug!(
+                        "Filename did not match established pattern: {}",
+                        file.name().to_string()
+                    );
+                    file.name().to_string()
+                }
+            } else {
+                file.name().to_string()
+            };
+
+            debug!("Reading file: {}", file.name());
+            let mut outfile =
+                File::create(openvpn_dir.join(filename.to_lowercase().replace(' ', "_")))?;
+            outfile.write_all(file_contents.as_slice())?;
+        }
+
+        // Write OpenVPN credentials file
+        let (user, pass) = self.prompt_for_auth()?;
+        let mut outfile = File::create(self.auth_file_path()?)?;
+        write!(outfile, "{}\n{}", user, pass)?;
+        Ok(())
+    }
+}
+
+#[derive(EnumIter, PartialEq)]
+enum ConfigType {
+    DefaultTcp,
+    Udp,
+    OnionTcp,
+    OnionUdp,
+    DoubleTcp,
+    DoubleUdp,
+}
+
+impl ConfigType {
+    fn get_protocol(&self) -> OpenVpnProtocol {
+        match self {
+            Self::DefaultTcp => OpenVpnProtocol::TCP,
+            Self::Udp => OpenVpnProtocol::UDP,
+            Self::OnionTcp => OpenVpnProtocol::TCP,
+            Self::OnionUdp => OpenVpnProtocol::UDP,
+            Self::DoubleTcp => OpenVpnProtocol::TCP,
+            Self::DoubleUdp => OpenVpnProtocol::UDP,
+        }
+    }
+
+    fn is_onion(&self) -> bool {
+        match self {
+            Self::OnionTcp => true,
+            Self::OnionUdp => true,
+            _ => false,
+        }
+    }
+
+    fn is_double(&self) -> bool {
+        match self {
+            Self::DoubleTcp => true,
+            Self::DoubleUdp => true,
+            _ => false,
+        }
+    }
+}
+
+impl Display for ConfigType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::DefaultTcp => "Default (TCP)",
+            Self::Udp => "UDP",
+            Self::OnionTcp => "Onion (TCP)",
+            Self::OnionUdp => "Onion (UDP)",
+            Self::DoubleTcp => "Double TCP",
+            Self::DoubleUdp => "Double UDP",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl Default for ConfigType {
+    fn default() -> Self {
+        Self::DefaultTcp
+    }
+}
+
+impl ConfigurationChoice for ConfigType {
+    fn prompt() -> String {
+        "Please choose the set of OpenVPN configuration files you wish to install".to_string()
+    }
+
+    fn variants() -> Vec<Self> {
+        ConfigType::iter().collect()
+    }
+    fn description(&self) -> Option<String> {
+        Some( match self {
+            Self::DefaultTcp => "These files connect over TCP.",
+            Self::Udp => "These files connect over UDP.",
+            Self::OnionTcp => "These files connect via Onion over VPN, using TCP.",
+            Self::OnionUdp => "These files connect via Onion over VPN, using UDP.",
+            Self::DoubleTcp => "These files connect over TCP across two separate VPN servers. The country listed is the initial outgoing VPN server.",
+            Self::DoubleUdp => "These files connect over UDP across two separate VPN servers. The country listed is the initial outgoing VPN server.",
+        }.to_string())
+    }
+}


### PR DESCRIPTION
Adding NordVPN to the list of providers. Note that this is only supported via OpenVPN. For wireguard, they've built an extra layer on top of it called [NordLynx](https://nordvpn.com/blog/nordlynx-protocol-wireguard/), which is intended to avoid having to store identifiable data on their servers. Unfortunately, they don't currently have any documentation on how to set up wireguard to connect to NordLynx. It's set up in their Linux client, but I don't know enough about wireguard config to be able to dig further to try to find out more details.