### PR TITLE
Fixed the broken iptables calls according to pre-nftables wg-quick src

### DIFF
--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -230,7 +230,7 @@ impl Wireguard {
                             namespace.exec(&[
                                 "ip6tables",
                                 "-t",
-                                "nat",
+                                "raw",
                                 "-A",
                                 "PREROUTING",
                                 "!",
@@ -238,12 +238,13 @@ impl Wireguard {
                                 &if_name,
                                 "-d",
                                 &address.to_string(),
+                                "-m",
                                 "addrtype",
                                 "!",
                                 "--src-type",
                                 "LOCAL",
                                 "-j",
-                                "REJECT",
+                                "DROP",
                             ])?;
                         }
 
@@ -251,7 +252,7 @@ impl Wireguard {
                             namespace.exec(&[
                                 "iptables",
                                 "-t",
-                                "nat",
+                                "raw",
                                 "-A",
                                 "PREROUTING",
                                 "!",
@@ -259,12 +260,13 @@ impl Wireguard {
                                 &if_name,
                                 "-d",
                                 &address.to_string(),
+                                "-m",
                                 "addrtype",
                                 "!",
                                 "--src-type",
                                 "LOCAL",
                                 "-j",
-                                "REJECT",
+                                "DROP",
                             ])?;
                         }
                     }


### PR DESCRIPTION
I fixed the broken ip(6)tables calls based on the pre-nftables version of wg-quick. Very small fix, seems to run fine. If wg-quick was correct then this is correct too.