### PR TITLE
Add ability to provide PostUp and PreDown scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.6.10"
+version = "0.7.0"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -31,12 +31,24 @@ firewall = "NfTables"
 provider = "Mullvad"
 protocol = "Wireguard"
 server = "usa-us22"
+postup = "/home/archie/postup.sh"
+predown = "/home/archie/predown.sh"
+user = "archie"
 # custom_config = "/home/user/vpn/mycustomconfig.ovpn"
 ```
 
 Note that the values are case-sensitive. If you use a custom config file
 then you should not set the provider or server (setting the protocol is
 also optional).
+
+### Host scripts
+
+Host scripts to run just after a network namespace is created and just before it is destroyed,
+can be provided with the `postup` and `predown` arguments (or in the `config.toml`).
+
+Note these scripts run on the host (outside the network namespace), using the current working directory,
+and with the same user as the final application itself (which can be set
+with the `user` argument or config file entry).
 
 ### Wireguard
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -116,6 +116,16 @@ pub struct ExecCommand {
     /// Block all IPv6 traffic
     #[structopt(long = "disable-ipv6")]
     pub disable_ipv6: bool,
+
+    /// Path or alias to executable PostUp script or binary for commands to run on the host after
+    /// bringing up the namespace
+    #[structopt(long = "postup")]
+    pub postup: Option<String>,
+
+    /// Path or alias to executable PreDown script or binary for commands to run on the host after
+    /// before shutting down the namespace
+    #[structopt(long = "predown")]
+    pub predown: Option<String>,
 }
 
 #[derive(StructOpt)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -328,7 +328,15 @@ pub fn get_configs_from_alias(list_path: &Path, alias: &str) -> Vec<PathBuf> {
                     .to_string(),
             )
         })
-        .filter(|x| x.2.starts_with(alias) || (x.1.starts_with(alias)))
+        .filter(|x| {
+            x.2.starts_with(alias)
+                || (x.1.starts_with(alias))
+                || x.0
+                    .file_name()
+                    .to_str()
+                    .expect("No filename")
+                    .starts_with(alias)
+        })
         .map(|x| PathBuf::from(x.0.path()))
         .collect::<Vec<PathBuf>>()
 }


### PR DESCRIPTION
See issue #71 

Also modified prefix for configs so that one can provide the precise config file name itself, in order to use a specific config (i.e. specific Mullvad US city for example) in the vopono config file.