### PR TITLE
Improve NetworkManager, firewalld support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
@@ -34,7 +34,7 @@ chrono = "0.4"
 compound_duration = "1"
 ipnet = {version = "2", features = ["serde"]}
 reqwest = {default-features = false, version = "0.11", features = ["blocking", "json", "rustls-tls"]}
-sysinfo = "0.19"
+sysinfo = "0.20"
 base64 = "0.13"
 x25519-dalek = "1"
 strum = "0.21"
@@ -48,6 +48,12 @@ config = "0.11"
 
 [package.metadata.rpm]
 package = "vopono"
+
+[package.metadata.deb]
+maintainer = "James McMurray <jamesmcm03@gmail.com>"
+recommends = "wireguard-tools, openvpn"
+# Not supported in Github Actions image with cargo-deb yet
+# suggests = "shadowsocks-libev, openfortivpn"
 
 [package.metadata.rpm.cargo]
 buildflags = ["--release"]

--- a/src/netns.rs
+++ b/src/netns.rs
@@ -154,7 +154,7 @@ impl NetworkNamespace {
         // TODO: Handle if name taken?
         let source = format!("{}_s", &self.name[7..self.name.len().min(20)]);
         let dest = format!("{}_d", &self.name[7..self.name.len().min(20)]);
-        self.veth_pair = Some(VethPair::new(source, dest, &self)?);
+        self.veth_pair = Some(VethPair::new(source, dest, self)?);
         Ok(())
     }
 
@@ -230,7 +230,7 @@ impl NetworkNamespace {
         disable_ipv6: bool,
     ) -> anyhow::Result<()> {
         self.openvpn = Some(OpenVpn::run(
-            &self,
+            self,
             config_file,
             auth_file,
             dns,
@@ -252,7 +252,7 @@ impl NetworkNamespace {
         server: &str,
     ) -> anyhow::Result<()> {
         self.openconnect = Some(OpenConnect::run(
-            &self,
+            self,
             config_file,
             open_ports,
             forward_ports,
@@ -288,7 +288,7 @@ impl NetworkNamespace {
         encrypt_method: &str,
     ) -> anyhow::Result<()> {
         self.shadowsocks = Some(Shadowsocks::run(
-            &self,
+            self,
             config_file,
             ss_host,
             listen_port,
@@ -425,7 +425,7 @@ impl Drop for NetworkNamespace {
                 std::env::set_var("VOPONO_NS", &self.name);
                 if self.predown_user.is_some() {
                     std::process::Command::new("sudo")
-                        .args(&["-Eu", self.predown_user.as_ref().unwrap(), &pdcmd])
+                        .args(&["-Eu", self.predown_user.as_ref().unwrap(), pdcmd])
                         .spawn()
                         .ok();
                 } else {

--- a/src/openconnect.rs
+++ b/src/openconnect.rs
@@ -52,12 +52,12 @@ impl OpenConnect {
 
         // Allow input to and output from open ports (for port forwarding in tunnel)
         if let Some(opens) = open_ports {
-            super::util::open_ports(&netns, opens.as_slice(), firewall)?;
+            super::util::open_ports(netns, opens.as_slice(), firewall)?;
         }
 
         // Allow input to and output from forwarded ports
         if let Some(forwards) = forward_ports {
-            super::util::open_ports(&netns, forwards.as_slice(), firewall)?;
+            super::util::open_ports(netns, forwards.as_slice(), firewall)?;
         }
 
         Ok(Self { pid: id })

--- a/src/openfortivpn.rs
+++ b/src/openfortivpn.rs
@@ -99,12 +99,12 @@ impl OpenFortiVpn {
         netns.dns_config(dns_ip.as_slice(), suffixes.as_slice())?;
         // Allow input to and output from open ports (for port forwarding in tunnel)
         if let Some(opens) = open_ports {
-            super::util::open_ports(&netns, opens.as_slice(), firewall)?;
+            super::util::open_ports(netns, opens.as_slice(), firewall)?;
         }
 
         // Allow input to and output from forwarded ports
         if let Some(forwards) = forward_ports {
-            super::util::open_ports(&netns, forwards.as_slice(), firewall)?;
+            super::util::open_ports(netns, forwards.as_slice(), firewall)?;
         }
 
         Ok(Self { pid: id })

--- a/src/openvpn.rs
+++ b/src/openvpn.rs
@@ -134,12 +134,12 @@ impl OpenVpn {
 
         // Allow input to and output from open ports (for port forwarding in tunnel)
         if let Some(opens) = open_ports {
-            super::util::open_ports(&netns, opens.as_slice(), firewall)?;
+            super::util::open_ports(netns, opens.as_slice(), firewall)?;
         }
 
         // Allow input to and output from forwarded ports (will be proxied to host)
         if let Some(forwards) = forward_ports {
-            super::util::open_ports(&netns, forwards.as_slice(), firewall)?;
+            super::util::open_ports(netns, forwards.as_slice(), firewall)?;
         }
 
         if use_killswitch {

--- a/src/providers/ivpn/wireguard.rs
+++ b/src/providers/ivpn/wireguard.rs
@@ -254,7 +254,7 @@ fn request_port() -> anyhow::Result<u16> {
     let port = Input::<u16>::new()
         .with_prompt("Enter port number:")
         .validate_with(|x: &u16| -> Result<(), &str> {
-          if [2049,2050,53,30587,41893,48574,58237].contains(&x) {
+          if [2049,2050,53,30587,41893,48574,58237].contains(x) {
               Ok(())
           } else {
               Err("Port must be one of: 2049,2050,53,30587,41893,48574,58237 (see https://www.ivpn.net/setup/gnu-linux-wireguard.html for ports reference)")

--- a/src/providers/mozilla/wireguard.rs
+++ b/src/providers/mozilla/wireguard.rs
@@ -52,7 +52,7 @@ impl MozillaVPN {
             .with_prompt(
                 "The following devices exist on your account, which would you like to use (you will need the private key)",
             )
-            .items(&devices)
+            .items(devices)
             .item("Create a new device (keypair)")
             .default(0)
             .interact()?;

--- a/src/providers/mullvad/wireguard.rs
+++ b/src/providers/mullvad/wireguard.rs
@@ -179,7 +179,7 @@ fn prompt_for_wg_key(
                 return Err(anyhow!("Cannot add more Wireguard keypairs to this account. Try to delete existing keypairs."));
             }
             let keypair = generate_keypair()?;
-            Mullvad::upload_wg_key(&client, auth_token, &keypair)?;
+            Mullvad::upload_wg_key(client, auth_token, &keypair)?;
             Ok(keypair)
         } else {
             let private_key = Input::<String>::new()

--- a/src/providers/nordvpn/openvpn.rs
+++ b/src/providers/nordvpn/openvpn.rs
@@ -82,7 +82,7 @@ impl OpenVpnProvider for NordVPN {
                 let server_name = fname.to_lowercase().replace(' ', "_");
                 let server_name = server_name.split('.').next().unwrap();
 
-                if let Some(cap) = server_regex.captures(&server_name) {
+                if let Some(cap) = server_regex.captures(server_name) {
                     // check whether the server is a special config type
                     // or not, and discard ones not in line with user's
                     // selection

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -123,7 +123,7 @@ impl Wireguard {
 
         let dns = dns.unwrap_or(&config.interface.dns);
         // TODO: DNS suffixes?
-        namespace.dns_config(&dns, &[])?;
+        namespace.dns_config(dns, &[])?;
         let fwmark = "51820";
         namespace.exec(&["wg", "set", &if_name, "fwmark", fwmark])?;
 
@@ -321,12 +321,12 @@ impl Wireguard {
 
         // Allow input to and output from open ports (for port forwarding in tunnel)
         if let Some(opens) = open_ports {
-            super::util::open_ports(&namespace, opens.as_slice(), firewall)?;
+            super::util::open_ports(namespace, opens.as_slice(), firewall)?;
         }
 
         // Allow input to and output from forwarded ports
         if let Some(forwards) = forward_ports {
-            super::util::open_ports(&namespace, forwards.as_slice(), firewall)?;
+            super::util::open_ports(namespace, forwards.as_slice(), firewall)?;
         }
 
         if use_killswitch {
@@ -443,7 +443,7 @@ impl Drop for Wireguard {
             "ip",
             "link",
             "del",
-            &if_name,
+            if_name,
         ]) {
             Ok(_) => {}
             Err(e) => warn!("Failed to delete ip link {}: {:?}", &self.ns_name, e),


### PR DESCRIPTION
Changes:

- Now check NetworkManager is actually running rather than just for the
  existence of the configuration file, before trying to apply
  NetworkManager config changes.
- Failure to apply NetworkManager config changes now results in a
  warning instead of an error.
- Added detection of systemd's firewalld to permit the veth device
  needed for the network namespace (much like with Network Manager
  previously).
- Added "recommends" dependencies to Debian dpkg with cargo-deb