### PR TITLE
Make conversion from Wireguard config format to TOML more robust and improve error output.

### DIFF
--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -69,7 +69,7 @@ impl Wireguard {
         }
         // TODO: Avoid hacky regex for valid toml
         let re = Regex::new(
-            r"(?m)^[[:blank:]]*(?P<key>[^\s]+)[[:blank:]]*=[[:blank:]]*(?P<value>[^\r\n]+?)[[:blank:]]*\r?$",
+            r"(?m)^[[:blank:]]*(?P<key>[^\s=#]+)[[:blank:]]*=[[:blank:]]*(?P<value>[^\r\n]+?)[[:blank:]]*\r?$",
         )?;
         let mut config_string = re
             .replace_all(&config_string, "$key = \"$value\"")

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -69,7 +69,7 @@ impl Wireguard {
         }
         // TODO: Avoid hacky regex for valid toml
         let re = Regex::new(
-            r"(?m)^[[:blank:]]*(?P<key>[^\s=#]+)[[:blank:]]*=[[:blank:]]*(?P<value>[^\r\n]+?)[[:blank:]]*\r?$",
+            r"(?m)^[[:blank:]]*(?P<key>[^\s=#]+)[[:blank:]]*=[[:blank:]]*(?P<value>[^\r\n#]+?)[[:blank:]]*(?:#[^\r\n]*)?\r?$",
         )?;
         let mut config_string = re
             .replace_all(&config_string, "$key = \"$value\"")


### PR DESCRIPTION
This change improves the regexp matching Wireguard config key/value pairs to allow spaces within the value.

It also improves the error message in the case where parsing the transformed config fails.

I don't think this regexp-based approach can actually be reliable (for one thing the `PostUp` and similar config keys could contain double quotes) but these changes should make failure less likely in the common case.

Closes #132 