### PR TITLE
Use custom_config variable to verify custom config is specified rather than only looking in commandline.

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -224,7 +224,7 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
     } else {
         // Config file required for non OpenConnect custom providers
         if protocol != Protocol::OpenConnect {
-            Some(command.custom_config.expect("No custom config provided"))
+            Some(custom_config.expect("No custom config provided"))
         } else {
             None
         }


### PR DESCRIPTION
**Note**: I made this change without really understanding the rest of the code or testing with non-custom providers. It  compiles appears to work in this case. It seems like the simple/obvious solution but I'm not 100% sure it's correct. Please review before merging.

Closes #134