### PR TITLE
Switch to Clap v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ keywords = ["vopono", "vpn", "wireguard", "openvpn", "netns"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3"
 anyhow = "1"
 directories-next = "2"
 log = "0.4"
 pretty_env_logger = "0.4"
-clap = "2"
+clap = {version = "3", features = ["derive"]}
 which = "4"
 users = "0.11"
 nix = "0.23"

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -78,6 +78,11 @@ $ vopono exec --provider mullvad --server sweden --protocol wireguard "transmiss
 The server prefix will be searched against available servers (and
 country names) and a random one will be chosen (and reported in the terminal).
 
+Note that vopono expects the `AllowedIPs` setting to allow all traffic,
+since all traffic in the vopono network namespace will be forced through
+this tunnel (traffic via the host is deliberately blocked to enforce the
+killswitch). e.g. it should be `AllowedIPs = 0.0.0.0/0,::/0`
+
 #### Custom Settings
 
 The sync menu will prompt you for any custom settings (i.e. ports used,

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,159 +2,159 @@ use super::firewall::Firewall;
 use super::network_interface::NetworkInterface;
 use super::providers::VpnProvider;
 use super::vpn::Protocol;
+use clap::Parser;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     name = "vopono",
     about = "Launch applications in a temporary VPN network namespace"
 )]
 pub struct App {
     /// Verbose output
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
     /// read sudo password from program specified in SUDO_ASKPASS environment variable
-    #[structopt(short = "A", long = "askpass")]
+    #[clap(short = 'A', long = "askpass")]
     pub askpass: bool,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub enum Command {
-    #[structopt(
+    #[clap(
         name = "exec",
         about = "Execute an application with the given VPN connection"
     )]
     Exec(ExecCommand),
-    #[structopt(
+    #[clap(
         name = "list",
         about = "List running vopono namespaces and applications"
     )]
     List(ListCommand),
-    #[structopt(
+    #[clap(
         name = "sync",
         about = "Synchronise local server lists with VPN providers"
     )]
     Synch(SynchCommand),
-    #[structopt(
+    #[clap(
         name = "servers",
         about = "List possible server configs for VPN provider, beginning with prefix"
     )]
     Servers(ServersCommand),
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct SynchCommand {
     /// VPN Provider - will launch interactive menu if not provided
-    #[structopt(possible_values = &VpnProvider::variants(), case_insensitive = true)]
+    #[clap(arg_enum, ignore_case = true)]
     pub vpn_provider: Option<VpnProvider>,
 
     /// VPN Protocol (if not given will try to sync both)
-    #[structopt(long = "protocol", short="c", possible_values = &Protocol::variants(), case_insensitive = true)]
+    #[clap(arg_enum, long = "protocol", short = 'c', ignore_case = true)]
     pub protocol: Option<Protocol>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct ExecCommand {
     /// VPN Provider (must be given unless using custom config)
-    #[structopt(long = "provider", short="p", possible_values = &VpnProvider::variants(), case_insensitive = true)]
+    #[clap(arg_enum, long = "provider", short = 'p', ignore_case = true)]
     pub vpn_provider: Option<VpnProvider>,
 
     /// VPN Protocol (if not given will use default)
-    #[structopt(long = "protocol", short="c", possible_values = &Protocol::variants(), case_insensitive = true)]
+    #[clap(arg_enum, long = "protocol", short = 'c', ignore_case = true)]
     pub protocol: Option<Protocol>,
 
     /// Network Interface (if not given, will use first active network interface)
-    #[structopt(long = "interface", short = "i", case_insensitive = true)]
+    #[clap(long = "interface", short = 'i', ignore_case = true)]
     pub interface: Option<NetworkInterface>,
 
     /// VPN Server prefix (must be given unless using custom config)
-    #[structopt(long = "server", short = "s")]
+    #[clap(long = "server", short = 's')]
     pub server: Option<String>,
 
     /// Application to run (should be on PATH or full path to binary)
     pub application: String,
 
     /// User with which to run the application (default is current user)
-    #[structopt(long = "user", short = "u")]
+    #[clap(long = "user", short = 'u')]
     pub user: Option<String>,
 
     /// Custom VPN Provider - OpenVPN or Wireguard config file (will override other settings)
-    #[structopt(parse(from_os_str), long = "custom")]
+    #[clap(parse(from_os_str), long = "custom")]
     pub custom_config: Option<PathBuf>,
 
     /// DNS Server (will override provider's DNS server)
-    #[structopt(long = "dns", short = "d")]
+    #[clap(long = "dns", short = 'd')]
     pub dns: Option<Vec<IpAddr>>,
 
     /// Disable killswitch
-    #[structopt(long = "no-killswitch")]
+    #[clap(long = "no-killswitch")]
     pub no_killswitch: bool,
 
     /// Keep-alive - do not close network namespace when launched process terminates
-    #[structopt(long = "keep-alive", short = "k")]
+    #[clap(long = "keep-alive", short = 'k')]
     pub keep_alive: bool,
 
     /// List of ports to open on network namespace (to allow port forwarding through the tunnel,
     /// e.g. for BitTorrent, etc.)
-    #[structopt(long = "open-ports", short = "o")]
+    #[clap(long = "open-ports", short = 'o')]
     pub open_ports: Option<Vec<u16>>,
 
     /// List of ports to forward from network namespace to host - useful for running servers and daemons
-    #[structopt(long = "forward", short = "f")]
+    #[clap(long = "forward", short = 'f')]
     pub forward_ports: Option<Vec<u16>>,
 
     /// Disable proxying to host machine when forwarding ports
-    #[structopt(long = "no-proxy")]
+    #[clap(long = "no-proxy")]
     pub no_proxy: bool,
 
     /// VPN Protocol (if not given will use default)
-    #[structopt(long = "firewall",  possible_values = &Firewall::variants(), case_insensitive = true)]
+    #[clap(arg_enum, long = "firewall", ignore_case = true)]
     pub firewall: Option<Firewall>,
 
     /// Block all IPv6 traffic
-    #[structopt(long = "disable-ipv6")]
+    #[clap(long = "disable-ipv6")]
     pub disable_ipv6: bool,
 
     /// Path or alias to executable PostUp script or binary for commands to run on the host after
     /// bringing up the namespace
-    #[structopt(long = "postup")]
+    #[clap(long = "postup")]
     pub postup: Option<String>,
 
     /// Path or alias to executable PreDown script or binary for commands to run on the host after
     /// before shutting down the namespace
-    #[structopt(long = "predown")]
+    #[clap(long = "predown")]
     pub predown: Option<String>,
 
     /// Path to vopono config TOML file (will be created if it does not exist)
     /// Default: ~/.config/vopono/config.toml
-    #[structopt(long = "vopono-config")]
+    #[clap(long = "vopono-config")]
     pub vopono_config: Option<PathBuf>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct ListCommand {
     /// VPN Provider
-    #[structopt(possible_values = &["namespaces", "applications"])]
+    #[clap(possible_values = &["namespaces", "applications"])]
     pub list_type: Option<String>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct ServersCommand {
     /// VPN Provider
-    #[structopt(possible_values = &VpnProvider::variants(), case_insensitive = true)]
+    #[clap(arg_enum, ignore_case = true)]
     pub vpn_provider: VpnProvider,
 
     /// VPN Protocol (if not given will list all)
-    #[structopt(long = "protocol", short="c", possible_values = &Protocol::variants(), case_insensitive = true)]
+    #[clap(arg_enum, long = "protocol", short = 'c', ignore_case = true)]
     pub protocol: Option<Protocol>,
 
     /// VPN Server prefix
-    #[structopt(long = "prefix", short = "s")]
+    #[clap(long = "prefix", short = 's')]
     pub prefix: Option<String>,
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -124,7 +124,7 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
             .unwrap_or_else(|| get_config_file_protocol(path));
         provider = VpnProvider::Custom;
         // Encode filename with base58 so we can fit it within 16 chars for the veth pair name
-        let sname = bs58::encode(&path.to_str().unwrap().to_string()).into_string();
+        let sname = bs58::encode(&path.to_str().unwrap()).into_string();
 
         server_name = sname[0..std::cmp::min(11, sname.len())].to_string();
     } else {
@@ -273,8 +273,7 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
                         provider
                             .get_dyn_openvpn_provider()
                             .ok()
-                            .map(|x| x.provider_dns())
-                            .flatten()
+                            .and_then(|x| x.provider_dns())
                     })
                     .unwrap_or_else(|| vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))]);
 

--- a/src/firewall.rs
+++ b/src/firewall.rs
@@ -1,13 +1,12 @@
 use crate::netns::NetworkNamespace;
-use clap::arg_enum;
+use clap::ArgEnum;
 use serde::{Deserialize, Serialize};
 
-arg_enum! {
-    #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy, ArgEnum)]
+#[clap(rename_all = "verbatim")]
 pub enum Firewall {
     IpTables,
     NfTables,
-}
 }
 
 pub fn disable_ipv6(netns: &NetworkNamespace, firewall: Firewall) -> anyhow::Result<()> {

--- a/src/list_configs.rs
+++ b/src/list_configs.rs
@@ -32,7 +32,7 @@ pub fn print_configs(cmd: ServersCommand) -> anyhow::Result<()> {
     }
 
     // Use get_configs_from_alias
-    let prefix = cmd.prefix.unwrap_or_else(String::new);
+    let prefix = cmd.prefix.unwrap_or_default();
     println!("provider\tprotocol\tconfig_file");
     if (cmd.protocol.is_none() && provider.get_dyn_openvpn_provider().is_ok())
         || cmd.protocol == Some(Protocol::OpenVpn)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,11 @@ mod veth_pair;
 mod vpn;
 mod wireguard;
 
+use clap::Parser;
 use list::output_list;
 use list_configs::print_configs;
 use log::{debug, warn, LevelFilter};
 use netns::NetworkNamespace;
-use structopt::StructOpt;
 use sync::{sync_menu, synch};
 use util::clean_dead_locks;
 use util::clean_dead_namespaces;
@@ -41,7 +41,7 @@ use which::which;
 
 fn main() -> anyhow::Result<()> {
     // Get struct of args using structopt
-    let app = args::App::from_args();
+    let app = args::App::parse();
 
     // Set up logging
     let mut builder = pretty_env_logger::formatted_timed_builder();

--- a/src/openconnect.rs
+++ b/src/openconnect.rs
@@ -29,8 +29,6 @@ impl OpenConnect {
             ));
         }
 
-        let handle;
-
         let creds = {
             if let Some(config_file) = config_file {
                 let config_file_path = config_file.canonicalize().context("Invalid path given")?;
@@ -45,7 +43,7 @@ impl OpenConnect {
         let user_arg = format!("--user={}", creds.0);
         let command_vec = (&["openconnect", &user_arg, "--passwd-on-stdin", server]).to_vec();
 
-        handle = netns
+        let handle = netns
             .exec_no_block(&command_vec, None, false, false, None)
             .context("Failed to launch OpenConnect - is openconnect installed?")?;
         let id = handle.id();

--- a/src/openfortivpn.rs
+++ b/src/openfortivpn.rs
@@ -31,8 +31,6 @@ impl OpenFortiVpn {
             ));
         }
 
-        let mut handle;
-
         info!("Launching OpenFortiVPN...");
         // Must run as root - https://github.com/adrienverge/openfortivpn/issues/650
         let command_vec = (&[
@@ -48,7 +46,7 @@ impl OpenFortiVpn {
         std::fs::remove_file(&pppd_log).ok();
 
         // TODO - better handle forwarding output when blocking on password entry (no newline!)
-        handle = netns
+        let mut handle = netns
             .exec_no_block(&command_vec, None, false, true, None)
             .context("Failed to launch OpenFortiVPN - is openfortivpn installed?")?;
         let stdout = handle.stdout.take().unwrap();

--- a/src/openvpn.rs
+++ b/src/openvpn.rs
@@ -42,7 +42,6 @@ impl OpenVpn {
             ));
         }
 
-        let handle;
         let log_file_str = format!("/etc/netns/{}/openvpn.log", &netns.name);
         {
             File::create(&log_file_str)?;
@@ -95,7 +94,7 @@ impl OpenVpn {
         debug!("Found remotes: {:?}", &remotes);
         let working_dir = PathBuf::from(config_file_path.parent().unwrap());
 
-        handle = netns
+        let handle = netns
             .exec_no_block(&command_vec, None, true, false, Some(working_dir))
             .context("Failed to launch OpenVPN - is openvpn installed?")?;
         let id = handle.id();
@@ -559,7 +558,7 @@ pub fn get_remotes_from_config(path: &Path) -> anyhow::Result<Vec<Remote>> {
 
     let re2 = Regex::new(r"proto ([a-z\-]+)")?;
     let mut caps2 = re2.captures_iter(&file_string);
-    let default_proto = caps2.next().map(|x| x.get(1)).flatten();
+    let default_proto = caps2.next().and_then(|x| x.get(1));
 
     for cap in caps {
         let proto = match (cap.get(3), default_proto) {

--- a/src/providers/airvpn/openvpn.rs
+++ b/src/providers/airvpn/openvpn.rs
@@ -57,7 +57,7 @@ impl OpenVpnProvider for AirVPN {
                 .get("public_name")
                 .unwrap()
                 .to_string()
-                .replace("\"", "");
+                .replace('\"', "");
             if !request_server_names.is_empty() {
                 // separate server names with '%2C'
                 request_server_names.push_str("%2C");

--- a/src/providers/azirevpn/mod.rs
+++ b/src/providers/azirevpn/mod.rs
@@ -39,7 +39,7 @@ struct ConnectResponse {
 #[derive(Deserialize, Debug, Clone)]
 struct WgResponse {
     #[serde(alias = "DNS", deserialize_with = "de_vec_ipaddr")]
-    dns: Vec<IpAddr>,
+    dns: Option<Vec<IpAddr>>,
     #[serde(alias = "Address", deserialize_with = "de_vec_ipnet")]
     address: Vec<IpNet>,
     #[serde(alias = "PublicKey")]

--- a/src/providers/hma/openvpn.rs
+++ b/src/providers/hma/openvpn.rs
@@ -70,8 +70,7 @@ impl OpenVpnProvider for HMA {
                 == Some("ovpn")
                 && path
                     .parent()
-                    .map(|x| x.file_name().map(|x| x.to_str()))
-                    .flatten()
+                    .and_then(|x| x.file_name().map(|x| x.to_str()))
                     .flatten()
                     == Some(&config_choice.dir_name())
                 && !path.starts_with("OpenVPN-2.4")
@@ -83,9 +82,9 @@ impl OpenVpnProvider for HMA {
                     .expect("Invalid filename");
                 let mut filename_iter = filename.split('.');
                 let country = filename_iter.next().unwrap();
-                let country = country.replace("'", "").replace("`", "").to_lowercase();
+                let country = country.replace('\'', "").replace('`', "").to_lowercase();
                 let city = filename_iter.next().unwrap();
-                let city = city.replace("'", "").replace("`", "").to_lowercase();
+                let city = city.replace('\'', "").replace('`', "").to_lowercase();
                 let filename = format!("{}-{}.ovpn", country, city);
                 let outpath = openvpn_dir.join(filename.to_lowercase().replace(' ', "_"));
                 debug!(

--- a/src/providers/ivpn/wireguard.rs
+++ b/src/providers/ivpn/wireguard.rs
@@ -149,7 +149,7 @@ impl WireguardProvider for IVPN {
         let interface = WireguardInterface {
             private_key: keypair.private,
             address: vec![ipnet],
-            dns: vec![IpAddr::from(dns)],
+            dns: Some(vec![IpAddr::from(dns)]),
         };
 
         let port = request_port()?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,7 +12,7 @@ mod tigervpn;
 use crate::util::vopono_dir;
 use crate::vpn::Protocol;
 use anyhow::anyhow;
-use clap::arg_enum;
+use clap::ArgEnum;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::net::IpAddr;
@@ -29,9 +29,9 @@ use std::string::ToString;
 // Methods should use dialoguer to request authentication, and reqwest for any HTTP requests
 // Should prompt user for any user input - i.e. port + protocol choice
 
-arg_enum! {
 /// enum used to accept VPN Provider as an argument
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, ArgEnum)]
+#[clap(rename_all = "verbatim")]
 pub enum VpnProvider {
     PrivateInternetAccess,
     Mullvad,
@@ -45,6 +45,11 @@ pub enum VpnProvider {
     HMA,
     Custom,
 }
+
+impl std::fmt::Display for VpnProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        std::fmt::Display::fmt(self.to_possible_value().unwrap().get_name(), f)
+    }
 }
 
 // Do this since we can't downcast from Provider to other trait objects

--- a/src/providers/mozilla/wireguard.rs
+++ b/src/providers/mozilla/wireguard.rs
@@ -149,7 +149,7 @@ impl WireguardProvider for MozillaVPN {
                 IpNet::from(wg_peer.ipv4_address),
                 IpNet::from(wg_peer.ipv6_address),
             ],
-            dns: vec![IpAddr::from(dns)],
+            dns: Some(vec![IpAddr::from(dns)]),
         };
 
         let port = request_port()?;

--- a/src/providers/mullvad/wireguard.rs
+++ b/src/providers/mullvad/wireguard.rs
@@ -90,7 +90,7 @@ impl WireguardProvider for Mullvad {
                 IpNet::from(wg_peer.ipv4_address),
                 IpNet::from(wg_peer.ipv6_address),
             ],
-            dns: vec![IpAddr::from(dns)],
+            dns: Some(vec![IpAddr::from(dns)]),
         };
 
         let port = request_port()?;

--- a/src/providers/nordvpn/openvpn.rs
+++ b/src/providers/nordvpn/openvpn.rs
@@ -102,7 +102,7 @@ impl OpenVpnProvider for NordVPN {
                             debug!("Could not map country code to name: {}", code.as_str());
                             fname.to_string()
                         } else {
-                            let server_name = server_name.replace("-", "_");
+                            let server_name = server_name.replace('-', "_");
                             format!("{}-{}.ovpn", country.unwrap(), server_name)
                         }
                     } else {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,18 +2,18 @@ use super::providers::VpnProvider;
 use super::util::set_config_permissions;
 use super::vpn::Protocol;
 use anyhow::bail;
+use clap::ArgEnum;
 use dialoguer::MultiSelect;
 use log::{error, info};
-use std::str::FromStr;
 
 pub fn sync_menu() -> anyhow::Result<()> {
-    let variants = VpnProvider::variants()
+    let variants = VpnProvider::value_variants()
         .iter()
-        .filter(|x| **x != "Custom")
+        .filter(|x| **x != VpnProvider::Custom)
         .map(|x| x.to_string())
         .collect::<Vec<String>>();
 
-    let selection = MultiSelect::new()
+    let selection: Vec<usize> = MultiSelect::new()
         .with_prompt("Which VPN providers do you wish to synchronise? Press Space to select and Enter to continue")
         .items(variants.as_slice())
         .interact()?;
@@ -24,8 +24,7 @@ pub fn sync_menu() -> anyhow::Result<()> {
 
     for provider in selection
         .into_iter()
-        .map(|x| VpnProvider::from_str(&variants[x]))
-        .flatten()
+        .flat_map(|x| VpnProvider::from_str(&variants[x], true))
     {
         synch(provider, None)?;
     }

--- a/src/vpn.rs
+++ b/src/vpn.rs
@@ -1,7 +1,7 @@
 use super::providers::ConfigurationChoice;
 use crate::providers::OpenVpnProvider;
 use anyhow::{anyhow, Context};
-use clap::arg_enum;
+use clap::ArgEnum;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -61,14 +61,19 @@ impl Display for OpenVpnProtocol {
     }
 }
 
-arg_enum! {
-    #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, ArgEnum)]
+#[clap(rename_all = "verbatim")]
 pub enum Protocol {
     OpenVpn,
     Wireguard,
     OpenConnect,
     OpenFortiVpn,
 }
+
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        std::fmt::Display::fmt(self.to_possible_value().unwrap().get_name(), f)
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -7,9 +7,9 @@ use log::{debug, error, warn};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
-use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -130,9 +130,15 @@ impl Wireguard {
         // TODO: Handle custom MTU
         namespace.exec(&["ip", "link", "set", "mtu", "1420", "up", "dev", &if_name])?;
 
-        let dns = dns.unwrap_or(&config.interface.dns);
+        let dns: Vec<IpAddr> = dns
+            .map(|x| x.clone())
+            .or(config.interface.dns.clone())
+            .unwrap_or_else(|| {
+                warn!("Found no DNS settings in Wireguard config, using 8.8.8.8");
+                vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))]
+            });
         // TODO: DNS suffixes?
-        namespace.dns_config(dns, &[])?;
+        namespace.dns_config(&dns, &[])?;
         let fwmark = "51820";
         namespace.exec(&["wg", "set", &if_name, "fwmark", fwmark])?;
 
@@ -484,7 +490,7 @@ pub struct WireguardInterface {
     #[serde(rename = "Address", deserialize_with = "de_vec_ipnet")]
     pub address: Vec<IpNet>,
     #[serde(rename = "DNS", deserialize_with = "de_vec_ipaddr")]
-    pub dns: Vec<IpAddr>,
+    pub dns: Option<Vec<IpAddr>>,
 }
 
 #[derive(Deserialize, Debug, Serialize)]
@@ -524,18 +530,25 @@ where
     }
 }
 
-pub fn de_vec_ipaddr<'de, D>(deserializer: D) -> Result<Vec<IpAddr>, D::Error>
+pub fn de_vec_ipaddr<'de, D>(deserializer: D) -> Result<Option<Vec<IpAddr>>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let raw = String::deserialize(deserializer)?;
+    let raw = match String::deserialize(deserializer) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("Missing optional DNS field in Wireguard config - serde");
+            debug!("serde: {:?}", e);
+            return Ok(None);
+        }
+    };
     debug!("Deserializing: {} to Vec<IpAddr>", raw);
     let strings = raw.split(',');
     match strings
         .map(|x| x.trim().parse::<IpAddr>())
         .collect::<Result<Vec<IpAddr>, _>>()
     {
-        Ok(x) => Ok(x),
+        Ok(x) => Ok(Some(x)),
         Err(x) => Err(serde::de::Error::custom(anyhow!(
             "Wireguard IpAddr deserialisation error: {:?}",
             x

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -131,8 +131,8 @@ impl Wireguard {
         namespace.exec(&["ip", "link", "set", "mtu", "1420", "up", "dev", &if_name])?;
 
         let dns: Vec<IpAddr> = dns
-            .map(|x| x.clone())
-            .or(config.interface.dns.clone())
+            .cloned()
+            .or_else(|| config.interface.dns.clone())
             .unwrap_or_else(|| {
                 warn!("Found no DNS settings in Wireguard config, using 8.8.8.8");
                 vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))]


### PR DESCRIPTION
StructOpt is removed as a dependency

Also make DNS setting in Wireguard config optional
And added note regarding AllowedIPs in Wireguard config needing to
allow all IPs as discussed in PR #135 

Closes issue #125 