### PR TITLE
Feature to allow the access to local hosted services

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -92,6 +92,14 @@ pub struct ExecCommand {
     #[clap(long = "dns", short = 'd')]
     pub dns: Option<Vec<IpAddr>>,
 
+    /// List of /etc/hosts entries for the network namespace (e.g. "10.0.1.10 webdav.server01.lan","10.0.1.10 vaultwarden.server01.lan"). For an local host you should also specifiy the open-hosts command
+    #[clap(long = "hosts", use_value_delimiter = true)]
+    pub hosts_entries: Option<Vec<String>>,
+
+    /// List of host ip's to open on network namespace (comma separated)
+    #[clap(long = "open-hosts", use_value_delimiter = true)]
+    pub open_hosts: Option<Vec<IpAddr>>,
+
     /// Disable killswitch
     #[clap(long = "no-killswitch")]
     pub no_killswitch: bool,

--- a/src/dns_config.rs
+++ b/src/dns_config.rs
@@ -69,33 +69,36 @@ impl DnsConfig {
             }
         }
 
-        let nsswitch_src = std::fs::File::open("/etc/nsswitch.conf")
-            .with_context(|| "Failed to open nsswitch.conf: /etc/nsswitch.conf")?;
+        if std::path::Path::new("/etc/nsswitch.conf").exists() {
+            let nsswitch_src = std::fs::File::open("/etc/nsswitch.conf")
+                .with_context(|| "Failed to open nsswitch.conf: /etc/nsswitch.conf")?;
 
-        let mut nsswitch = std::fs::File::create(format!("/etc/netns/{}/nsswitch.conf", ns_name))
-            .with_context(|| {
-            format!(
-                "Failed to open nsswitch.conf: /etc/netns/{}/nsswitch.conf",
-                ns_name
-            )
-        })?;
+            let mut nsswitch =
+                std::fs::File::create(format!("/etc/netns/{}/nsswitch.conf", ns_name))
+                    .with_context(|| {
+                        format!(
+                            "Failed to open nsswitch.conf: /etc/netns/{}/nsswitch.conf",
+                            ns_name
+                        )
+                    })?;
 
-        for line in std::io::BufReader::new(nsswitch_src).lines() {
-            writeln!(
-                nsswitch,
-                "{}",
-                Regex::new(r"^hosts:.*$")
-                    .unwrap()
-                    .replace(&line?, |_caps: &Captures| {
-                        "hosts: files mymachines myhostname dns"
-                    })
-            )
-            .with_context(|| {
-                format!(
-                    "Failed to overwrite nsswitch.conf: /etc/netns/{}/nsswitch.conf",
-                    ns_name
+            for line in std::io::BufReader::new(nsswitch_src).lines() {
+                writeln!(
+                    nsswitch,
+                    "{}",
+                    Regex::new(r"^hosts:.*$")
+                        .unwrap()
+                        .replace(&line?, |_caps: &Captures| {
+                            "hosts: files mymachines myhostname dns"
+                        })
                 )
-            })?;
+                .with_context(|| {
+                    format!(
+                        "Failed to overwrite nsswitch.conf: /etc/netns/{}/nsswitch.conf",
+                        ns_name
+                    )
+                })?;
+            }
         }
 
         Ok(Self { ns_name })

--- a/src/dns_config.rs
+++ b/src/dns_config.rs
@@ -1,10 +1,10 @@
 use anyhow::Context;
 use log::{debug, warn};
+use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};
+use std::io::BufRead;
 use std::io::Write;
 use std::net::IpAddr;
-use std::io::BufRead;
-use regex::{Regex,Captures};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DnsConfig {
@@ -12,7 +12,12 @@ pub struct DnsConfig {
 }
 
 impl DnsConfig {
-    pub fn new(ns_name: String, servers: &[IpAddr], suffixes: &[&str], hosts_entries: Option<&Vec<String>>) -> anyhow::Result<Self> {
+    pub fn new(
+        ns_name: String,
+        servers: &[IpAddr],
+        suffixes: &[&str],
+        hosts_entries: Option<&Vec<String>>,
+    ) -> anyhow::Result<Self> {
         std::fs::create_dir_all(format!("/etc/netns/{}", ns_name))
             .with_context(|| format!("Failed to create directory: /etc/netns/{}", ns_name))?;
 
@@ -55,38 +60,37 @@ impl DnsConfig {
 
         if let Some(my_hosts_entries) = hosts_entries {
             let mut hosts = std::fs::File::create(format!("/etc/netns/{}/hosts", ns_name))
-                .with_context(|| {
-                    format!(
-                        "Failed to open hosts: /etc/netns/{}/hosts",
-                        ns_name
-                    )
-                })?;
+                .with_context(|| format!("Failed to open hosts: /etc/netns/{}/hosts", ns_name))?;
 
             for hosts_enty in my_hosts_entries {
                 writeln!(hosts, "{}", hosts_enty).with_context(|| {
-                    format!(
-                        "Failed to overwrite hosts: /etc/netns/{}/hosts",
-                        ns_name
-                    )
+                    format!("Failed to overwrite hosts: /etc/netns/{}/hosts", ns_name)
                 })?;
             }
         }
 
         let nsswitch_src = std::fs::File::open("/etc/nsswitch.conf")
-            .with_context(|| {
-                "Failed to open nsswitch.conf: /etc/nsswitch.conf"
-            })?;
+            .with_context(|| "Failed to open nsswitch.conf: /etc/nsswitch.conf")?;
 
         let mut nsswitch = std::fs::File::create(format!("/etc/netns/{}/nsswitch.conf", ns_name))
             .with_context(|| {
-                format!(
-                    "Failed to open nsswitch.conf: /etc/netns/{}/nsswitch.conf",
-                    ns_name
-                )
-            })?;
+            format!(
+                "Failed to open nsswitch.conf: /etc/netns/{}/nsswitch.conf",
+                ns_name
+            )
+        })?;
 
         for line in std::io::BufReader::new(nsswitch_src).lines() {
-            writeln!(nsswitch, "{}", Regex::new(r"^hosts:.*$").unwrap().replace(&line?, |_caps: &Captures| { "hosts: files mymachines myhostname dns" })).with_context(|| {
+            writeln!(
+                nsswitch,
+                "{}",
+                Regex::new(r"^hosts:.*$")
+                    .unwrap()
+                    .replace(&line?, |_caps: &Captures| {
+                        "hosts: files mymachines myhostname dns"
+                    })
+            )
+            .with_context(|| {
                 format!(
                     "Failed to overwrite nsswitch.conf: /etc/netns/{}/nsswitch.conf",
                     ns_name

--- a/src/netns.rs
+++ b/src/netns.rs
@@ -158,7 +158,11 @@ impl NetworkNamespace {
         Ok(())
     }
 
-    pub fn add_routing(&mut self, target_subnet: u8, hosts: Option<Vec<IpAddr>>) -> anyhow::Result<()> {
+    pub fn add_routing(
+        &mut self,
+        target_subnet: u8,
+        hosts: Option<Vec<IpAddr>>,
+    ) -> anyhow::Result<()> {
         // TODO: Handle case where IP address taken in better way i.e. don't just change subnet
         let veth_dest = &self
             .veth_pair
@@ -212,7 +216,12 @@ impl NetworkNamespace {
                     "dev",
                     veth_source,
                 ])
-                .with_context(|| format!("Failed to assign hosts route to veth source: {}", veth_source))?;
+                .with_context(|| {
+                    format!(
+                        "Failed to assign hosts route to veth source: {}",
+                        veth_source
+                    )
+                })?;
             }
         }
 
@@ -228,8 +237,18 @@ impl NetworkNamespace {
         Ok(())
     }
 
-    pub fn dns_config(&mut self, server: &[IpAddr], suffixes: &[&str], hosts_entries: Option<&Vec<String>>) -> anyhow::Result<()> {
-        self.dns_config = Some(DnsConfig::new(self.name.clone(), server, suffixes, hosts_entries)?);
+    pub fn dns_config(
+        &mut self,
+        server: &[IpAddr],
+        suffixes: &[&str],
+        hosts_entries: Option<&Vec<String>>,
+    ) -> anyhow::Result<()> {
+        self.dns_config = Some(DnsConfig::new(
+            self.name.clone(),
+            server,
+            suffixes,
+            hosts_entries,
+        )?);
         Ok(())
     }
 

--- a/src/openfortivpn.rs
+++ b/src/openfortivpn.rs
@@ -21,6 +21,7 @@ impl OpenFortiVpn {
         config_file: PathBuf,
         open_ports: Option<&Vec<u16>>,
         forward_ports: Option<&Vec<u16>>,
+        hosts_entries: Option<&Vec<String>>,
         firewall: Firewall,
     ) -> anyhow::Result<Self> {
         if let Err(x) = which::which("openfortivpn") {
@@ -94,7 +95,7 @@ impl OpenFortiVpn {
         let dns_ip: Vec<IpAddr> = (dns.0).into_iter().map(IpAddr::from).collect();
         // TODO: Avoid this meaningless collect
         let suffixes: Vec<&str> = (dns.1).iter().map(|x| x.as_str()).collect();
-        netns.dns_config(dns_ip.as_slice(), suffixes.as_slice())?;
+        netns.dns_config(dns_ip.as_slice(), suffixes.as_slice(), hosts_entries)?;
         // Allow input to and output from open ports (for port forwarding in tunnel)
         if let Some(opens) = open_ports {
             super::util::open_ports(netns, opens.as_slice(), firewall)?;

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -30,6 +30,7 @@ impl Wireguard {
         firewall: Firewall,
         disable_ipv6: bool,
         dns: Option<&Vec<IpAddr>>,
+        hosts_entries: Option<&Vec<String>>,
     ) -> anyhow::Result<Self> {
         if let Err(x) = which::which("wg") {
             error!("wg binary not found. Is wireguard-tools installed and on PATH?");
@@ -138,7 +139,7 @@ impl Wireguard {
                 vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))]
             });
         // TODO: DNS suffixes?
-        namespace.dns_config(&dns, &[])?;
+        namespace.dns_config(&dns, &[], hosts_entries)?;
         let fwmark = "51820";
         namespace.exec(&["wg", "set", &if_name, "fwmark", fwmark])?;
 


### PR DESCRIPTION
I would like to use vopono in combination with a web browser. I have not found a safe way to integrate my locally hosted services like vaultwarden for password management and webdav to synchronize the bookmarks in the current vopono version. Therefore I have added two parameters to vopono `exec` command:

- `--open-hosts <OPEN_HOSTS>`: List of host ip's to open on network namespace (comma separated)
- `--hosts <HOSTS_ENTRIES>`:  List of `/etc/hosts` entries for the network namespace (e.g. "10.0.1.10             webdav.server01.lan","10.0.1.10 vaultwarden.server01.lan"). This acts mainly as a dns rewrite/override for an local domain.

