### PR TITLE
Only log last OpneVPN log line (instead of the whole log file for every line in the log file)

### DIFF
--- a/src/openvpn.rs
+++ b/src/openvpn.rs
@@ -111,7 +111,7 @@ impl OpenVpn {
             let x = logfile.read_line(&mut buffer)?;
 
             if x > 0 {
-                debug!("{}", &buffer[pos..].trim());
+                debug!("{}", &buffer[pos..].trim_end());
             }
 
             pos += x;


### PR DESCRIPTION
Currently, the whole OpenVPN log file is logged, for every line in the OpenVPN log (which results in a huge amount of log output). This PR fixes this, making it easier to read the log output of OpenVPN.