### PR TITLE
Expose $VOPONO_NS_IP environment variable to the PostUp and PreDown scripts, and the application to run 

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -49,6 +49,13 @@ The current network namespace name is provided to the PostUp and PreDown
 scripts in the environment variable `$VOPONO_NS`. It is temporarily set
 when running these scripts only.
 
+Similarly, the network namespace IP address is provided via `$VOPONO_NS_IP`,
+and is available to the PostUp and PreDown scripts, and the application to
+run itself. `$VOPONO_NS_IP` is useful if you'd like to configure a server
+running within the network namespace to listen on its local IP address only
+(see below, for more information on that).
+
+
 ### Host scripts
 
 Host scripts to run just after a network namespace is created and just before it is destroyed,
@@ -266,12 +273,19 @@ Note in the case of `transmission-daemon` the `-a *.*.*.*` argument is
 required to allow external connections to the daemon's web portal (your
 host machine will now count as external to the network namespace).
 
+Instead of listening on `*.*.*.*` you also can listen on `$VOPONO_NS_IP`,
+to listen on an IP address that is only reachable from the same machine,
+the network namespace runs on.
+
 When finished with vopono, you must manually kill the
 `transmission-daemon` since the PID changes (i.e. use `killall`).
 
 By default, vopono runs a small TCP proxy to proxy the ports on your
 host machine to the ports on the network namespace - if you do not want
 this to run use the `--no-proxy` flag.
+
+In this case, you can read the IP of the network namespace from the
+terminal, or use `$VOPONO_NS_IP` to get it (e.g. to use it in a script).
 
 #### systemd service
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -370,6 +370,13 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
             }
         }
 
+        // Temporarily set env var referring to this network namespace IP
+        // for the PostUp script and the application:
+        std::env::set_var(
+            "VOPONO_NS_IP",
+            &ns.veth_pair_ips.as_ref().unwrap().namespace_ip.to_string(),
+        );
+
         // Run PostUp script (if any)
         // Temporarily set env var referring to this network namespace name
         if let Some(pucmd) = postup {
@@ -388,6 +395,8 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
     let ns = ns.write_lockfile(&command.application)?;
 
     let application = ApplicationWrapper::new(&ns, &command.application, user)?;
+
+    std::env::remove_var("VOPONO_NS_IP");
 
     // Launch TCP proxy server on other threads if forwarding ports
     // TODO: Fix when running as root

--- a/src/netns.rs
+++ b/src/netns.rs
@@ -462,6 +462,15 @@ impl Drop for NetworkNamespace {
             // Run PreDown script (if any)
             if let Some(pdcmd) = self.predown.as_ref() {
                 std::env::set_var("VOPONO_NS", &self.name);
+                std::env::set_var(
+                    "VOPONO_NS_IP",
+                    &self
+                        .veth_pair_ips
+                        .as_ref()
+                        .unwrap()
+                        .namespace_ip
+                        .to_string(),
+                );
                 if self.predown_user.is_some() {
                     std::process::Command::new("sudo")
                         .args(&["-Eu", self.predown_user.as_ref().unwrap(), pdcmd])
@@ -471,6 +480,7 @@ impl Drop for NetworkNamespace {
                     std::process::Command::new(&pdcmd).spawn().ok();
                 }
                 std::env::remove_var("VOPONO_NS");
+                std::env::remove_var("VOPONO_NS_IP");
             }
 
             self.openvpn = None;


### PR DESCRIPTION
This looked easy to implement, so I thought I just implement it myself.

`VOPONO_NS_IP` is exposed to the application to run because this might be useful for configuring it (e.g. for the `transmission-daemon` that is mentioned in the user guide).

Please feel free to edit/remove any of my additions to the user guide however you like (English isn't my native language, in case that isn't clear by now... ;)).

I don't really know much about networking, and I'm not 100% sure that everything I wrote is correct (especially, that the network namespace IP isn't reachable from other machines in the local network).

Please let me know if you think there is anything that might be wrong.