### PR TITLE
Expose $VOPONO_HOST_IP environment variable to the application to run

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -59,7 +59,7 @@ The application to run within the namespace also has access to
 `$VOPONO_HOST_IP`, to get the IP address of the host.
 
 Note: These environment variables are currently only available from within
-the application/script to run, not from the command line. So the following
+the application/script to run, not on the command line. So the following
 doesn't work:
 
 `vopono exec {other Vopono options} 'echo "HOST IP: $VOPONO_HOST_IP"'`
@@ -94,8 +94,14 @@ Note these scripts run on the host (outside the network namespace), using the cu
 and with the same user as the final application itself (which can be set
 with the `user` argument or config file entry).
 
-Shell commands (e.g. `echo POSTUP`) and script arguments (e.g. `script.sh arg1 arg1`),
-are currently not possible (resulting in the script to fail).
+Script arguments (e.g. `script.sh arg1 arg1`), are currently not possible, resulting in an error:
+
+```
+$ vopono exec {other Vopono options} --postup 'echo POSTUP' ls
+[...]
+sudo: echo POSTUP: command not found
+[...]
+```
 
 ### Wireguard
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -55,6 +55,35 @@ run itself. `$VOPONO_NS_IP` is useful if you'd like to configure a server
 running within the network namespace to listen on its local IP address only
 (see below, for more information on that).
 
+The application to run within the namespace also has access to
+`$VOPONO_HOST_IP`, to get the IP address of the host.
+
+Note: These environment variables are currently only available from within
+the application/script to run, not from the command line. So the following
+doesn't work:
+
+`vopono exec {other Vopono options} 'echo "HOST IP: $VOPONO_HOST_IP"'`
+
+Output: `HOST IP: $VOPONO_HOST_IP` (the environ variable wasn't expanded).
+
+A work around is to create a executable script, that executes the 
+application you'd like to run:
+
+```bash
+#!/bin/bash
+
+echo "=> NETWORK NAMESPACE IP: $VOPONO_NS_IP"
+echo "=> HOST IP: $VOPONO_HOST_IP"
+```
+
+Execution: `vopono exec {other Vopono options} '/path/to/the/above/script.sh'`
+
+Output:
+
+```
+=> NETWORK NAMESPACE IP: 10.200.1.2
+=> HOST IP: 10.200.1.1
+```
 
 ### Host scripts
 
@@ -64,6 +93,9 @@ can be provided with the `postup` and `predown` arguments (or in the `config.tom
 Note these scripts run on the host (outside the network namespace), using the current working directory,
 and with the same user as the final application itself (which can be set
 with the `user` argument or config file entry).
+
+Shell commands (e.g. `echo POSTUP`) and script arguments (e.g. `script.sh arg1 arg1`),
+are currently not possible (resulting in the script to fail).
 
 ### Wireguard
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -392,11 +392,15 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
         }
     }
 
+    // Set env var referring to the host IP for the application:
+    std::env::set_var(
+        "VOPONO_HOST_IP",
+        &ns.veth_pair_ips.as_ref().unwrap().host_ip.to_string(),
+    );
+
     let ns = ns.write_lockfile(&command.application)?;
 
     let application = ApplicationWrapper::new(&ns, &command.application, user)?;
-
-    std::env::remove_var("VOPONO_NS_IP");
 
     // Launch TCP proxy server on other threads if forwarding ports
     // TODO: Fix when running as root
@@ -437,6 +441,9 @@ pub fn exec(command: ExecCommand) -> anyhow::Result<()> {
         info!("Keep-alive flag active - will leave network namespace alive until ctrl+C received");
         stay_alive(None, signals);
     }
+
+    std::env::remove_var("VOPONO_NS_IP");
+    std::env::remove_var("VOPONO_HOST_IP");
 
     Ok(())
 }


### PR DESCRIPTION
I've added the [suggested](https://github.com/jamesmcm/vopono/pull/154) $VOPONO_HOST_IP environment variable.

The environment variables are now valid for the whole execution of the application (before, we might have removed the variables too early).

I've also added a few caveats to the guide regarding the environment variables and the PostUp/PreDown scripts.