### PR TITLE
vopono 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"
@@ -19,7 +19,7 @@ pretty_env_logger = "0.4"
 clap = {version = "3", features = ["derive"]}
 which = "4"
 users = "0.11"
-nix = "0.23"
+nix = "0.24"
 serde = {version = "1", features = ["derive", "std"]}
 csv = "1"
 dialoguer ="0.10"
@@ -40,7 +40,7 @@ strum = "0.24"
 strum_macros = "0.24"
 zip = "0.6"
 maplit = "1"
-webbrowser = "0.6"
+webbrowser = "0.7"
 basic_tcp_proxy = "0.3"
 signal-hook = "0.3"
 config = "0.13"

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -300,6 +300,8 @@ Note for same daemons you may need to use the `-k` keep-alive option in
 case the process ID changes (you will then need to manually kill the
 daemon after finishing).
 
+#### transmission-daemon
+
 For example, to launch `transmission-daemon` that is externally
 accessible at `127.0.0.1:9091` (with outward connections via AzireVPN with Wireguard and a VPN server in Norway):
 
@@ -317,6 +319,19 @@ the network namespace runs on.
 
 When finished with vopono, you must manually kill the
 `transmission-daemon` since the PID changes (i.e. use `killall`).
+
+#### Jackett
+
+The same approach also works for [Jackett](https://github.com/Jackett/Jackett), e.g. with the setup from
+the [AUR PKGBUILD](https://aur.archlinux.org/packages/jackett-bin) (a separate `jackett` user and hosting on port `9117`):
+
+```bash
+$ vopono -v exec -u jackett "/usr/lib/jackett/jackett --NoRestart --NoUpdates --DataFolder /var/lib/jackett" -f 9117
+```
+
+You can then access the web UI on the host machine at `http://127.0.0.1:9117/UI/Dashboard`, but all of Jackett's connections will go via the VPN.
+
+#### Proxy to host
 
 By default, vopono runs a small TCP proxy to proxy the ports on your
 host machine to the ports on the network namespace - if you do not want


### PR DESCRIPTION
- Updated dependencies
- Added warning when there are multiple active network interfaces (issue #149 )
- Sets 644 permissions for netns configs explicitly ( issue #156  )
- Added Jackett example to user guide