### PR TITLE
fix(openconnect): let openconnect use its config

### DIFF
--- a/src/netns.rs
+++ b/src/netns.rs
@@ -125,6 +125,7 @@ impl NetworkNamespace {
             handle.stdout(Stdio::piped());
             handle.stderr(Stdio::piped());
         }
+        handle.stdin(Stdio::piped());
 
         debug!(
             "ip netns exec {}{} {}",
@@ -280,7 +281,7 @@ impl NetworkNamespace {
 
     pub fn run_openconnect(
         &mut self,
-        config_file: Option<PathBuf>,
+        config_file: PathBuf,
         open_ports: Option<&Vec<u16>>,
         forward_ports: Option<&Vec<u16>>,
         firewall: Firewall,


### PR DESCRIPTION
- Openconnect will now use the custom config provided to Vopono.
- Openconnect is now able to authenticate with the provided password
- It's not possible to provide a username via Vopono to Openconnect. This is due to there not being a simple optional way to provide it and the username clashing with the one provided in the openconnect-config.
- Openconnect will use the optionally provided server, or the server from its custom config. If both are provided openconnect will fail.

An example minimal openconnect.conf which can be provided as a custom config:
with server:
```
server = vpn.example.com
user = user
```
without server:
```
user = user
```
Generally you can add all command-line-arguments from openconnect. E.g. my tested VPN-config would look like this:
```
server = vpn.example.com
user = user
authgroup = group
no-dtls
```
from this oppenconnect-command: `openconnect --user user --authgroup group --no-dtls --passwd-on-stdin vpn.example.com`. Note, that passwd-onstdin is always added in vopono and shouldn't be set in the config.

Fixes #39
