### PR TITLE
vopono 0.10.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,20 @@ jobs:
       with:
         name: armv5-deb
         path: ./target/armv5te-unknown-linux-musleabi/debian/*
+  aarch64deb:
+    needs: [build]
+    runs-on: ubuntu-latest
+    name: Aarch64Deb
+    steps:
+    - uses: actions/checkout@v2
+    - name: BuildDeb
+      id: debbuild
+      uses: jamesmcm/cargo-deb-aarch64-debian@master
+    - name: Upload Deb Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: aarch64-deb
+        path: ./target/aarch64-unknown-linux-musl/debian/*
   amd64binaries:
     needs: [build, quickcheck]
     runs-on: ubuntu-latest
@@ -168,8 +182,28 @@ jobs:
       with:
         name: armv5
         path: ./target/armv5te-unknown-linux-musleabi/release/vopono
+  aarch64binaries:
+    needs: [build, quickcheck]
+    runs-on: ubuntu-latest
+    name: Aarch64StaticBinaries
+    steps:
+    - uses: actions/checkout@v2
+    - id: cargoversion
+      run: cargo --version
+    - id: rustcversion
+      run: rustc --version
+    - name: StaticBinaryBuild
+      id: aarch64staticbuild
+      uses: jamesmcm/cargo-deb-aarch64-debian@master
+      with:
+        cmd: cargo build --release --target=aarch64-unknown-linux-musl
+    - name: Upload Vopono Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: aarch64
+        path: ./target/aarch64-unknown-linux-musl/release/vopono
   update_release_draft:
-    needs: [quickcheck, build, arm7binaries, arm5binaries, amd64binaries, raspbianbuild, armv5deb, debbuild, opensuseleaprpmbuild, fedorarpmbuild]
+    needs: [quickcheck, build, arm7binaries, arm5binaries, aarch64binaries, amd64binaries, raspbianbuild, armv5deb, aarch64deb, debbuild, opensuseleaprpmbuild, fedorarpmbuild]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -193,6 +227,8 @@ jobs:
       - run: ls -lha armv7
       - run: ls -lha armv5-deb
       - run: ls -lha armv5
+      - run: ls -lha aarch64-deb
+      - run: ls -lha aarch64
       - run: ls -lha fedorarpm
       - run: ls -lha opensuserpm
       - name: Upload amd64 deb Release Asset
@@ -221,6 +257,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./armv5-deb/vopono_${{needs.quickcheck.outputs.version}}_armel.deb
           asset_name: 'vopono_${{needs.quickcheck.outputs.version}}_armel.deb'
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload aarch64 deb Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./aarch64-deb/vopono_${{needs.quickcheck.outputs.version}}_aarch64.deb
+          asset_name: 'vopono_${{needs.quickcheck.outputs.version}}_aarch64.deb'
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload amd64 rpm fedora Release Asset
         uses: actions/upload-release-asset@v1
@@ -257,6 +302,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./armv5/vopono
           asset_name: 'vopono_${{needs.quickcheck.outputs.version}}_linux_armv5'
+          asset_content_type: application/octet-stream
+      - name: Upload Aarch64 Static Binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./aarch64/vopono
+          asset_name: 'vopono_${{needs.quickcheck.outputs.version}}_linux_aarch64'
           asset_content_type: application/octet-stream
       - name: Upload Amd64 Static Binary
         uses: actions/upload-release-asset@v1

--- a/src/args.rs
+++ b/src/args.rs
@@ -194,6 +194,15 @@ pub struct ExecCommand {
     /// Default: ~/.config/vopono/config.toml
     #[clap(long = "vopono-config")]
     pub vopono_config: Option<PathBuf>,
+
+    /// Custom name for the generated network namespace
+    /// Will use this network namespace directly if it exists
+    #[clap(long = "custom-netns-name")]
+    pub custom_netns_name: Option<String>,
+    /// Allow access to host from network namespace
+    /// Useful for accessing services on the host locally
+    #[clap(long = "allow-host-access")]
+    pub allow_host_access: bool,
 }
 
 #[derive(Parser)]

--- a/vopono_core/src/network/application_wrapper.rs
+++ b/vopono_core/src/network/application_wrapper.rs
@@ -34,7 +34,7 @@ impl ApplicationWrapper {
         }
 
         // TODO: Could allow user to set custom working directory here
-        let handle = netns.exec_no_block(app_vec.as_slice(), user, false, false, None)?;
+        let handle = netns.exec_no_block(app_vec.as_slice(), user, false, false, false, None)?;
         Ok(Self { handle })
     }
 

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -157,7 +157,8 @@ impl NetworkNamespace {
 
     pub fn add_veth_pair(&mut self) -> anyhow::Result<()> {
         // TODO: Handle if name taken?
-        let basename = &self.name[(self.name.len() - 13).max(0)..self.name.len()];
+        // Use bs58 here?
+        let basename = &self.name[((self.name.len() as i32) - 13).max(0) as usize..self.name.len()];
         let source = format!("{}_s", basename);
         let dest = format!("{}_d", basename);
         self.veth_pair = Some(VethPair::new(source, dest, self)?);

--- a/vopono_core/src/network/openconnect.rs
+++ b/vopono_core/src/network/openconnect.rs
@@ -50,7 +50,7 @@ impl OpenConnect {
         }
 
         let handle = netns
-            .exec_no_block(&command_vec, None, false, false, None)
+            .exec_no_block(&command_vec, None, false, false, true, None)
             .context("Failed to launch OpenConnect - is openconnect installed?")?;
 
         handle

--- a/vopono_core/src/network/openfortivpn.rs
+++ b/vopono_core/src/network/openfortivpn.rs
@@ -48,7 +48,7 @@ impl OpenFortiVpn {
 
         // TODO - better handle forwarding output when blocking on password entry (no newline!)
         let mut handle = netns
-            .exec_no_block(&command_vec, None, false, true, None)
+            .exec_no_block(&command_vec, None, false, true, false, None)
             .context("Failed to launch OpenFortiVPN - is openfortivpn installed?")?;
         let stdout = handle.stdout.take().unwrap();
         let id = handle.id();

--- a/vopono_core/src/network/shadowsocks.rs
+++ b/vopono_core/src/network/shadowsocks.rs
@@ -67,7 +67,7 @@ impl Shadowsocks {
         ];
 
         let handle = netns
-            .exec_no_block(&command_vec, None, true, false, None)
+            .exec_no_block(&command_vec, None, true, false, false, None)
             .context("Failed to launch Shadowsocks - is shadowsocks-libev installed?")?;
 
         Ok(Self { pid: handle.id() })


### PR DESCRIPTION
Fixes:
- #174  - now only the OpenConnect invocation takes over stdin itself, bash works again :slightly_smiling_face: 
- #175 - "dead" namespaces will not be cleaned if there are PIDs running - however this does not apply to the vopono namespace cleaning itself up - i.e. if you use the same network namespace and vopono with different users at the same time then closing either one would still clean up the network namespace.
- #169 - aarch64 binaries and deb added to Github action
- #172 and #173 - UI code has been refactored into UIClient trait and clap ArgEnum enums are wrapped with the WrappedArg struct in `args.rs`
- #159 - with the `--allow-host-access` flag to access the local host (note the host IP address will likely be `10.200.1.1` (or `10.200.x.1` when running multiple vopono instances) - you must use that to access it from inside the network namespace).
- #131 -  you can use `--custom-netns-name` to override the network namespace name, and `--open-hosts` should work for allowing access to the shadowsocks server for scripting.