### PR TITLE
Add ability to set group and working directory for command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -135,6 +135,14 @@ pub struct ExecCommand {
     #[clap(long = "user", short = 'u')]
     pub user: Option<String>,
 
+    /// Group with which to run the application
+    #[clap(long = "group", short = 'g')]
+    pub group: Option<String>,
+
+    /// Working directory in which to run the application (default is current working directory)
+    #[clap(long = "working-directory", short = 'w')]
+    pub working_directory: Option<String>,
+
     /// Custom VPN Provider - OpenVPN or Wireguard config file (will override other settings)
     #[clap(parse(from_os_str), long = "custom")]
     pub custom_config: Option<PathBuf>,

--- a/vopono_core/src/network/application_wrapper.rs
+++ b/vopono_core/src/network/application_wrapper.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::netns::NetworkNamespace;
 use crate::util::get_all_running_process_names;
 use log::warn;
@@ -11,6 +13,8 @@ impl ApplicationWrapper {
         netns: &NetworkNamespace,
         application: &str,
         user: Option<String>,
+        group: Option<String>,
+        working_directory: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let running_processes = get_all_running_process_names();
         let app_vec = application.split_whitespace().collect::<Vec<_>>();
@@ -33,8 +37,15 @@ impl ApplicationWrapper {
             }
         }
 
-        // TODO: Could allow user to set custom working directory here
-        let handle = netns.exec_no_block(app_vec.as_slice(), user, false, false, false, None)?;
+        let handle = netns.exec_no_block(
+            app_vec.as_slice(),
+            user,
+            group,
+            false,
+            false,
+            false,
+            working_directory,
+        )?;
         Ok(Self { handle })
     }
 

--- a/vopono_core/src/network/openconnect.rs
+++ b/vopono_core/src/network/openconnect.rs
@@ -50,7 +50,7 @@ impl OpenConnect {
         }
 
         let handle = netns
-            .exec_no_block(&command_vec, None, false, false, true, None)
+            .exec_no_block(&command_vec, None, None, false, false, true, None)
             .context("Failed to launch OpenConnect - is openconnect installed?")?;
 
         handle

--- a/vopono_core/src/network/openfortivpn.rs
+++ b/vopono_core/src/network/openfortivpn.rs
@@ -48,7 +48,7 @@ impl OpenFortiVpn {
 
         // TODO - better handle forwarding output when blocking on password entry (no newline!)
         let mut handle = netns
-            .exec_no_block(&command_vec, None, false, true, false, None)
+            .exec_no_block(&command_vec, None, None, false, true, false, None)
             .context("Failed to launch OpenFortiVPN - is openfortivpn installed?")?;
         let stdout = handle.stdout.take().unwrap();
         let id = handle.id();

--- a/vopono_core/src/network/openvpn.rs
+++ b/vopono_core/src/network/openvpn.rs
@@ -98,7 +98,15 @@ impl OpenVpn {
         let working_dir = PathBuf::from(config_file_path.parent().unwrap());
 
         let handle = netns
-            .exec_no_block(&command_vec, None, true, false, false, Some(working_dir))
+            .exec_no_block(
+                &command_vec,
+                None,
+                None,
+                true,
+                false,
+                false,
+                Some(working_dir),
+            )
             .context("Failed to launch OpenVPN - is openvpn installed?")?;
         let id = handle.id();
         let mut buffer = String::with_capacity(16384);

--- a/vopono_core/src/network/shadowsocks.rs
+++ b/vopono_core/src/network/shadowsocks.rs
@@ -67,7 +67,7 @@ impl Shadowsocks {
         ];
 
         let handle = netns
-            .exec_no_block(&command_vec, None, true, false, false, None)
+            .exec_no_block(&command_vec, None, None, true, false, false, None)
             .context("Failed to launch Shadowsocks - is shadowsocks-libev installed?")?;
 
         Ok(Self { pid: handle.id() })


### PR DESCRIPTION
```
$ cargo run -- exec -c Wireguard --custom mullvad-de11.conf -u deluge --postup 'id' --predown 'id' id
[...]
uid=993(deluge) gid=993(deluge) groups=993(deluge)
uid=993(deluge) gid=993(deluge) groups=993(deluge)
uid=993(deluge) gid=993(deluge) groups=993(deluge)
[...]
$ cargo run -- exec -c Wireguard --custom mullvad-de11.conf -u deluge -g users --postup 'id' --predown 'id' id
[...]
uid=993(deluge) gid=100(users) groups=100(users),993(deluge)
uid=993(deluge) gid=100(users) groups=100(users),993(deluge)
uid=993(deluge) gid=100(users) groups=100(users),993(deluge)
[...]
$ cargo run -- exec -c Wireguard --custom mullvad-de11.conf -w /tmp pwd
[...]
/tmp
[...]
$ cargo run -- exec -c Wireguard --custom mullvad-de11.conf pwd
[...]
/home/hashworks/Documents/Projects/Rust/vopono
[...]
```