### PR TITLE
Allow DNS Names in Custom Wiregaurd Configs

### DIFF
--- a/vopono_core/src/network/wireguard.rs
+++ b/vopono_core/src/network/wireguard.rs
@@ -508,7 +508,7 @@ pub struct WireguardPeer {
     pub public_key: String,
     #[serde(rename = "AllowedIPs", deserialize_with = "de_vec_ipnet")]
     pub allowed_ips: Vec<IpNet>,
-    #[serde(rename = "Endpoint")]
+    #[serde(rename = "Endpoint", deserialize_with = "de_socketaddr")]
     pub endpoint: SocketAddr,
     #[serde(rename = "PersistentKeepalive")]
     pub keepalive: Option<String>,


### PR DESCRIPTION
Fix wiregaurd config parser such that deserializer is called correctly.

To reproduce the bug use a custom wiregaurd config with a DNS name in the `Peer.Endpoint` section. This MR corrects the bug by invoking the deserializer which in turn calls `toSocket`

https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html