### PR TITLE
Improved netns name generation

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -278,13 +278,18 @@ pub fn exec(command: ExecCommand, uiclient: &dyn UiClient) -> anyhow::Result<()>
 
     let alias = match provider {
         VpnProvider::Custom => "c".to_string(),
-        _ => provider.get_dyn_provider().alias(),
+        _ => provider.get_dyn_provider().alias_2char(),
     };
 
     let ns_name = if let Some(c_ns_name) = custom_netns_name {
         c_ns_name
     } else {
-        format!("vopono_{alias}_{server_name}")
+        let short_name = if server_name.len() > 7 {
+            bs58::encode(&server_name).into_string()[0..7].to_string()
+        } else {
+            server_name.clone()
+        };
+        format!("vo_{alias}_{short_name}")
     };
 
     let mut ns;

--- a/vopono_core/src/config/providers/airvpn/mod.rs
+++ b/vopono_core/src/config/providers/airvpn/mod.rs
@@ -10,6 +10,10 @@ impl Provider for AirVPN {
         "air".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "ar".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/config/providers/azirevpn/mod.rs
+++ b/vopono_core/src/config/providers/azirevpn/mod.rs
@@ -24,6 +24,10 @@ impl Provider for AzireVPN {
     fn alias(&self) -> String {
         "azire".to_string()
     }
+    fn alias_2char(&self) -> String {
+        "az".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::Wireguard
     }

--- a/vopono_core/src/config/providers/hma/mod.rs
+++ b/vopono_core/src/config/providers/hma/mod.rs
@@ -11,6 +11,10 @@ impl Provider for HMA {
         "hma".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "hm".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/config/providers/ivpn/mod.rs
+++ b/vopono_core/src/config/providers/ivpn/mod.rs
@@ -12,6 +12,10 @@ impl Provider for IVPN {
         "ivpn".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "iv".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::Wireguard
     }

--- a/vopono_core/src/config/providers/mod.rs
+++ b/vopono_core/src/config/providers/mod.rs
@@ -101,6 +101,8 @@ impl VpnProvider {
 pub trait Provider {
     fn alias(&self) -> String;
 
+    fn alias_2char(&self) -> String;
+
     fn default_protocol(&self) -> Protocol;
 
     fn provider_dir(&self) -> anyhow::Result<PathBuf> {

--- a/vopono_core/src/config/providers/mozilla/mod.rs
+++ b/vopono_core/src/config/providers/mozilla/mod.rs
@@ -55,6 +55,11 @@ impl Provider for MozillaVPN {
     fn alias(&self) -> String {
         "mozilla".to_string()
     }
+
+    fn alias_2char(&self) -> String {
+        "mz".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::Wireguard
     }

--- a/vopono_core/src/config/providers/mullvad/mod.rs
+++ b/vopono_core/src/config/providers/mullvad/mod.rs
@@ -37,6 +37,11 @@ impl Provider for Mullvad {
     fn alias(&self) -> String {
         "mv".to_string()
     }
+
+    fn alias_2char(&self) -> String {
+        "mv".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::Wireguard
     }

--- a/vopono_core/src/config/providers/nordvpn/mod.rs
+++ b/vopono_core/src/config/providers/nordvpn/mod.rs
@@ -10,6 +10,10 @@ impl Provider for NordVPN {
         "nordvpn".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "nd".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/config/providers/pia/mod.rs
+++ b/vopono_core/src/config/providers/pia/mod.rs
@@ -13,6 +13,10 @@ impl Provider for PrivateInternetAccess {
         "pia".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "pi".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/config/providers/protonvpn/mod.rs
+++ b/vopono_core/src/config/providers/protonvpn/mod.rs
@@ -10,6 +10,10 @@ impl Provider for ProtonVPN {
         "proton".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "pr".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/config/providers/tigervpn/mod.rs
+++ b/vopono_core/src/config/providers/tigervpn/mod.rs
@@ -64,6 +64,10 @@ impl Provider for TigerVPN {
         "tig".to_string()
     }
 
+    fn alias_2char(&self) -> String {
+        "ti".to_string()
+    }
+
     fn default_protocol(&self) -> Protocol {
         Protocol::OpenVpn
     }

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -176,10 +176,8 @@ impl NetworkNamespace {
 
     pub fn add_veth_pair(&mut self) -> anyhow::Result<()> {
         // TODO: Handle if name taken?
-        // Use bs58 here?
-        let basename = &self.name[((self.name.len() as i32) - 13).max(0) as usize..self.name.len()];
-        let source = format!("{basename}_s");
-        let dest = format!("{basename}_d");
+        let source = format!("{}_s", self.name);
+        let dest = format!("{}_d", self.name);
         self.veth_pair = Some(VethPair::new(source, dest, self)?);
         Ok(())
     }


### PR DESCRIPTION
The generation of netns/veth names is changed as discussed in #177.
This makes the names usable in firewall rules while still limiting their length.
If necessary the server/config-name is converted to a 7-character hash.