### PR TITLE
Fix pactl parsing when in non-English language

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -287,7 +287,7 @@ pub fn exec(command: ExecCommand, uiclient: &dyn UiClient) -> anyhow::Result<()>
         let short_name = if server_name.len() > 7 {
             bs58::encode(&server_name).into_string()[0..7].to_string()
         } else {
-            server_name.clone()
+            server_name.replace('-', "")
         };
         format!("vo_{alias}_{short_name}")
     };

--- a/vopono_core/src/util/pulseaudio.rs
+++ b/vopono_core/src/util/pulseaudio.rs
@@ -4,8 +4,11 @@ use regex::Regex;
 use std::process::Command;
 
 pub fn get_pulseaudio_server() -> anyhow::Result<String> {
-    let output = Command::new("pactl").args(["info"]).output()?.stdout;
-    let re = Regex::new(r"Server String: ([^\n]+)").unwrap();
+    let output = Command::new("pactl")
+        .args(["-f", "json", "info"])
+        .output()?
+        .stdout;
+    let re = Regex::new("\"server_string\":\"([^\"]+)\"").unwrap();
     let output = std::str::from_utf8(&output)?;
 
     let caps = re.captures(output);


### PR DESCRIPTION
Also strip out '-' from network namespace name even when under 7 characters to avoid syntax errors

Fixes #219 and ensures #218 doesn't occur even for short server names.

Note we could use `serde_json` instead but it seemed overkill for one field (although note we do it use it in `vopono sync` anyway).