### PR TITLE
Fix sync for ProtonVPN OpenVPN configs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.10.5"
+version = "0.10.6"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -28,13 +28,20 @@ lynx all running through different VPN connections:
 | Mullvad               | ✅              | ✅                |
 | AzireVPN              | ✅              | ✅                |
 | iVPN                  | ✅              | ✅                |
-| PrivateInternetAccess | ✅              | ✅                |
+| PrivateInternetAccess | ✅              | ✅\*\*            |
 | TigerVPN              | ✅              | ❌                |
-| ProtonVPN             | ✅              | ❌                |
+| ProtonVPN             | ✅              | ❓\*              |
 | MozillaVPN            | ❌              | ✅                |
 | NordVPN               | ✅              | ❌                |
 | HMA (HideMyAss)       | ✅              | ❌                |
 | AirVPN                | ✅              | ❌                |
+
+\* For ProtonVPN you can generate and download specific Wireguard config
+files, and use them as a custom provider config. See the [User Guide](USERGUIDE.md)
+for details - note that port forwarding is not supported for ProtonVPN
+(but is for Mullvad).
+
+\*\* Port forwarding is not currently supported for PrivateInternetAccess.
 
 ## Usage
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -453,7 +453,24 @@ for the same (note the instructions on disabling WebRTC). I noticed that
 when using IPv6 with OpenVPN it incorrectly states you are not connected
 via AzireVPN though (Wireguard works correctly).
 
+ProtonVPN users must log-in to the dashboard via a web browser during
+the `vopono sync` process in order to copy the `AUTH-*` cookie to
+access the OpenVPN configuration files, and the OpenVPN specific
+credentials to use them.
+
 ### VPN Provider limitations
+
+#### ProtonVPN
+
+Due to the way Wireguard configuration is handled, this should be
+generated online and then used as a custom configuration, e.g.:
+
+```bash
+$ vopono -v exec --provider custom --custom testwg-UK-17.conf --protocol wireguard firefox-developer-edition
+```
+
+Note that port forwarding is not supported for ProtonVPN (but is for
+Mullvad).
 
 #### PrivateInternetAccess
 

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono_core"
 description = "Library code for running VPN connections in network namespaces"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 license = "GPL-3.0-or-later"
@@ -31,7 +31,7 @@ reqwest = { default-features = false, version = "0.11", features = [
     "json",
     "rustls-tls",
 ] } # TODO: Can we remove Tokio dependency?
-sysinfo = "0.28"
+sysinfo = "0.29"
 base64 = "0.21"
 x25519-dalek = "1"
 strum = "0.24"

--- a/vopono_core/src/config/providers/mod.rs
+++ b/vopono_core/src/config/providers/mod.rs
@@ -8,6 +8,7 @@ mod nordvpn;
 mod pia;
 mod protonvpn;
 mod tigervpn;
+mod ui;
 
 use crate::config::vpn::Protocol;
 use crate::util::vopono_dir;
@@ -16,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{net::IpAddr, path::Path};
 use strum_macros::{Display, EnumIter};
+// TODO: Consider removing this re-export
+pub use ui::*;
 
 // Command-line arguments use VpnProvider enum
 // We pattern match on that to build an instance of the actual provider struct
@@ -141,62 +144,4 @@ pub trait OpenVpnProvider: Provider {
 pub trait ShadowsocksProvider: Provider {
     fn password(&self) -> String;
     fn encrypt_method(&self) -> String;
-}
-
-/// Implement this trait for enums used as configuration choices e.g. when deciding which set of
-/// config files to generate
-/// The default option will be used if generated in non-interactive mode
-pub trait ConfigurationChoice {
-    /// Prompt string for the selector (automatically terminates in ':')
-    fn prompt(&self) -> String;
-
-    /// Descriptions are a user-friendly descriptions for each enum variant
-    fn description(&self) -> Option<String>;
-
-    /// Descriptions are a user-friendly descriptions for each enum variant
-    fn all_descriptions(&self) -> Option<Vec<String>>;
-
-    /// Get all enum variant names (this order will be used for other methods)
-    fn all_names(&self) -> Vec<String>;
-}
-// TODO: FromStr, ToString
-
-pub struct BoolChoice {
-    pub prompt: String,
-    pub default: bool,
-}
-
-#[allow(clippy::type_complexity)]
-/// Only supports strings
-pub struct Input {
-    pub prompt: String,
-    pub validator: Option<Box<dyn Fn(&String) -> core::result::Result<(), String>>>,
-}
-
-#[allow(clippy::type_complexity)]
-/// Only supports u16 input - so UI Client can allow numbers only
-pub struct InputNumericu16 {
-    pub prompt: String,
-    pub validator: Option<Box<dyn Fn(&u16) -> core::result::Result<(), String>>>,
-    pub default: Option<u16>,
-}
-
-pub struct Password {
-    pub prompt: String,
-    pub confirm: bool,
-}
-
-/// Trait to be implemented by a struct wrapping the user-facing client code
-/// e.g. separate implementations for CLI, TUI, GUI, etc.
-/// For GUI and TUI may want to override `process_choices()` to get the responses in a batch
-pub trait UiClient {
-    /// Returns index of chosen element from ConfigurationChoice - this can then be used with concrete enum::variants() for concrete variant
-    fn get_configuration_choice(
-        &self,
-        conf_choice: &dyn ConfigurationChoice,
-    ) -> anyhow::Result<usize>;
-    fn get_bool_choice(&self, bool_choice: BoolChoice) -> anyhow::Result<bool>;
-    fn get_input(&self, input: Input) -> anyhow::Result<String>;
-    fn get_input_numeric_u16(&self, input: InputNumericu16) -> anyhow::Result<u16>;
-    fn get_password(&self, password: Password) -> anyhow::Result<String>;
 }

--- a/vopono_core/src/config/providers/ui.rs
+++ b/vopono_core/src/config/providers/ui.rs
@@ -1,0 +1,57 @@
+/// Implement this trait for enums used as configuration choices e.g. when deciding which set of
+/// config files to generate
+/// The default option will be used if generated in non-interactive mode
+pub trait ConfigurationChoice {
+    /// Prompt string for the selector (automatically terminates in ':')
+    fn prompt(&self) -> String;
+
+    /// Descriptions are a user-friendly descriptions for each enum variant
+    fn description(&self) -> Option<String>;
+
+    /// Descriptions are a user-friendly descriptions for each enum variant
+    fn all_descriptions(&self) -> Option<Vec<String>>;
+
+    /// Get all enum variant names (this order will be used for other methods)
+    fn all_names(&self) -> Vec<String>;
+}
+// TODO: FromStr, ToString
+
+pub struct BoolChoice {
+    pub prompt: String,
+    pub default: bool,
+}
+
+#[allow(clippy::type_complexity)]
+/// Only supports strings
+pub struct Input {
+    pub prompt: String,
+    pub validator: Option<Box<dyn Fn(&String) -> core::result::Result<(), String>>>,
+}
+
+#[allow(clippy::type_complexity)]
+/// Only supports u16 input - so UI Client can allow numbers only
+pub struct InputNumericu16 {
+    pub prompt: String,
+    pub validator: Option<Box<dyn Fn(&u16) -> core::result::Result<(), String>>>,
+    pub default: Option<u16>,
+}
+
+pub struct Password {
+    pub prompt: String,
+    pub confirm: bool,
+}
+
+/// Trait to be implemented by a struct wrapping the user-facing client code
+/// e.g. separate implementations for CLI, TUI, GUI, etc.
+/// For GUI and TUI may want to override `process_choices()` to get the responses in a batch
+pub trait UiClient {
+    /// Returns index of chosen element from ConfigurationChoice - this can then be used with concrete enum::variants() for concrete variant
+    fn get_configuration_choice(
+        &self,
+        conf_choice: &dyn ConfigurationChoice,
+    ) -> anyhow::Result<usize>;
+    fn get_bool_choice(&self, bool_choice: BoolChoice) -> anyhow::Result<bool>;
+    fn get_input(&self, input: Input) -> anyhow::Result<String>;
+    fn get_input_numeric_u16(&self, input: InputNumericu16) -> anyhow::Result<u16>;
+    fn get_password(&self, password: Password) -> anyhow::Result<String>;
+}

--- a/vopono_core/src/config/vpn.rs
+++ b/vopono_core/src/config/vpn.rs
@@ -1,6 +1,5 @@
-use super::providers::ConfigurationChoice;
 use super::providers::OpenVpnProvider;
-use super::providers::UiClient;
+use super::providers::{ConfigurationChoice, UiClient};
 use anyhow::{anyhow, Context};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
ProtonVPN now requires the user to be authenticated to access the configuration files.

We now request that the user log in via their browser and then copy the value of the `AUTH-` cookie.

Note the `Feature` specification for filtering for Tor / Torrent optimised servers has been removed from ProtonVPN's configuration page, and so is removed here too.

Also note that for SecureCore configs, the first name in the filename is the output node country, as this is probably the most useful for filtering.

Fixes issue #201 