### PR TITLE
Remove Mullvad API usage for Wireguard keys

### DIFF
--- a/vopono_core/src/config/providers/mozilla/wireguard.rs
+++ b/vopono_core/src/config/providers/mozilla/wireguard.rs
@@ -280,7 +280,6 @@ struct WireguardRelay {
     ipv6_addr_in: std::net::Ipv6Addr,
     pubkey: String,
     multihop_port: u16,
-    socks_name: String,
 }
 
 #[derive(Serialize, Debug)]

--- a/vopono_core/src/config/providers/mullvad/mod.rs
+++ b/vopono_core/src/config/providers/mullvad/mod.rs
@@ -10,11 +10,6 @@ use crate::util::wireguard::WgPeer;
 use anyhow::anyhow;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
-struct AuthToken {
-    auth_token: String,
-}
-
 #[allow(dead_code)]
 #[derive(Deserialize, Debug, Clone)]
 struct UserInfo {
@@ -23,12 +18,6 @@ struct UserInfo {
     max_wg_peers: u8,
     can_add_wg_peers: bool,
     wg_peers: Vec<WgPeer>,
-}
-
-// TODO: use Json::Value to remove this?
-#[derive(Deserialize, Debug)]
-struct UserResponse {
-    account: UserInfo,
 }
 
 pub struct Mullvad {}

--- a/vopono_core/src/config/providers/mullvad/openvpn.rs
+++ b/vopono_core/src/config/providers/mullvad/openvpn.rs
@@ -120,7 +120,8 @@ impl OpenVpnProvider for Mullvad {
                     relay.ipv4_addr_in, port, relay.hostname
                 )
             } else {
-                format!("remote {}.mullvad.net {}", relay.hostname, port)
+                // TODO: Use fqdn here?
+                format!("remote {}.relays.mullvad.net {}", relay.hostname, port)
             };
 
             file_set.entry(file_name).or_default().push(remote_string);


### PR DESCRIPTION
Mullvad has unfortunately deprecated the API for handling Wireguard keys See issue #243  - https://github.com/jamesmcm/vopono/issues/243

This change removes that code and relies on the user uploading their Wireguard public key and recording the return IPv4 and IPv6 ranges directly.