### PR TITLE
Fix port forwarding for custom ProtonVPN WG config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 dialoguer
+test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ signal-hook = "0.3"
 walkdir = "2"
 chrono = "0.4"
 bs58 = "0.5"
-nix = { version = "0.27", features = ["signal", "process"] }
-config = "0.13"
+nix = { version = "0.28", features = ["signal", "process"] }
+config = "0.14"
 basic_tcp_proxy = "0.3.2"
-strum = "0.25"
-strum_macros = "0.25"
+strum = "0.26"
+strum_macros = "0.26"
 
 [package.metadata.rpm]
 package = "vopono"

--- a/README.md
+++ b/README.md
@@ -43,11 +43,20 @@ lynx all running through different VPN connections:
 
 \*\*\* For ProtonVPN you can generate and download specific Wireguard config
 files, and use them as a custom provider config. See the [User Guide](USERGUIDE.md)
-for details. [Port Forwarding](https://protonvpn.com/support/port-forwarding-manual-setup/) is supported with the `--port-forwarding` argument for both OpenVPN and Wireguard (with `--provider custom --custom xxx.conf --protocol wireguard` ). `natpmpc` must be installed. Note for OpenVPN you must generate the OpenVPN config files appending `+pmp` to your OpenVPN username, and you must choose servers which support this feature (e.g. at the time of writing, the Romania servers do). The assigned port is then printed to the terminal where vopono was launched - this should then be set in any applications that require it.
+for details. [Port Forwarding](https://protonvpn.com/support/port-forwarding-manual-setup/) is supported with the `--port-forwarding` argument for both OpenVPN and Wireguard.
+Note for using a custom config with Wireguard, the port forwarding implementation to be used should be specified with `--custom-port-forwarding`
+(i.e. with `--provider custom --custom xxx.conf --protocol wireguard --custom-port-forwarding protonvpn` ). `natpmpc` must be installed.
+Note for OpenVPN you must generate the OpenVPN config files appending `+pmp` to your OpenVPN username, and you must choose servers which support this feature
+(e.g. at the time of writing, the Romania servers do). The assigned port is then printed to the terminal where vopono was launched - this should then be set in any applications that require it.
+The port can also be passed to a custom script that will be executed
+within the network namespace via the `--port-forwarding-callback`
+argument.
 
 
 \*\*\*\* Cloudflare Warp uses its own protocol. Set both the provider and
-protocol to `warp`. Note you must first register with `sudo warp-cli register` and then run it once with `sudo warp-svc` and `sudo warp-cli connect` outside of vopono. Please verify this works first before trying it with vopono.
+protocol to `warp`. Note you must first register with `sudo warp-cli register` and then run it once with `sudo warp-svc` and `sudo warp-cli connect` outside of vopono.
+Please verify this works first before trying it with vopono. Note there
+may also be issues with Warp overriding the DNS settings.
 
 
 ## Usage
@@ -175,7 +184,7 @@ $ rustc --version
 - When launching a new application in an existing vopono namespace, any
   modifications to the firewall rules (i.e. forwarding and opening
   ports) will not be applied (they are only used when creating the
-  namespace).
+  namespace). The same applies for port forwarding.
 - OpenVPN credentials are always stored in plaintext in configuration - may add
   option to not store credentials, but it seems OpenVPN needs them
   provided in plaintext.

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -488,7 +488,7 @@ Due to the way Wireguard configuration generation is handled, this should be
 generated online and then used as a custom configuration, e.g.:
 
 ```bash
-$ vopono -v exec --provider custom --custom testwg-UK-17.conf --protocol wireguard --port-forwarding firefox-developer-edition
+$ vopono -v exec --provider custom --custom testwg-UK-17.conf --protocol wireguard --custom-port-forwarding protonvpn firefox-developer-edition
 ```
 
 #### Port Forwarding
@@ -508,9 +508,20 @@ The port you are allocated will then be printed to the console like:
 
 And that is the port you would then set up in applications that require it.
 
+For Wireguard custom configs mentioned above, you must set the
+`--custom-port-forwarding protonvpn` argument, so vopono knows which
+port forwarding implementation to use for the custom config file.
+
+The port can also be passed to a script (which will be executed within
+the network namespace every 45 seconds when the port is refreshed) by passing the script 
+as the `--port-forwarding-callback` argument - the port will be passed
+as the first argument (i.e. `$1`).
+
 ### PrivateInternetAccess
 
 Port forwaring supported with the `--port-forwarding` option, use the `--port-forwarding-callback` option to specify a command to run when the port is refreshed.
+
+Note the usual `-o` / `--open-ports` argument has no effect here as we only know the port number assigned after connecting to PIA.
 
 ### Cloudflare Warp
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -144,7 +144,6 @@ pub struct ExecCommand {
     pub working_directory: Option<String>,
 
     /// Custom VPN Provider - OpenVPN or Wireguard config file (will override other settings)
-    // TODO: Check From OsStr part works
     #[clap(long = "custom")]
     pub custom_config: Option<PathBuf>,
 
@@ -216,6 +215,10 @@ pub struct ExecCommand {
     /// Enable port forwarding for if supported
     #[clap(long = "port-forwarding")]
     pub port_forwarding: bool,
+
+    /// Port forwarding implementation to use for custom config file with --custom-config
+    #[clap(long = "custom-port-forwarding", ignore_case = true)]
+    pub custom_port_forwarding: Option<WrappedArg<VpnProvider>>,
 
     /// Path or alias to executable script or binary to be called with the port as an argumnet
     /// when the port forwarding is refreshed (PIA only)

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -16,7 +16,7 @@ directories-next = "2"
 log = "0.4"
 which = "6"
 users = "0.11"
-nix = { version = "0.27", features = ["user", "signal", "fs", "process"] }
+nix = { version = "0.28", features = ["user", "signal", "fs", "process"] }
 serde = { version = "1", features = ["derive", "std"] }
 csv = "1"
 regex = "1"
@@ -33,8 +33,8 @@ reqwest = { default-features = false, version = "0.11", features = [
 sysinfo = "0.30"
 base64 = "0.21"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
-strum = "0.25"
-strum_macros = "0.25"
+strum = "0.26"
+strum_macros = "0.26"
 zip = "0.6"
 maplit = "1"
 webbrowser = "0.8"

--- a/vopono_core/src/network/piapf.rs
+++ b/vopono_core/src/network/piapf.rs
@@ -169,6 +169,7 @@ impl Piapf {
         })
     }
 
+    // TODO: Refactor methods below into Trait
     fn refresh_port(params: &ThreadParams) -> anyhow::Result<u16> {
         let bind_response = NetworkNamespace::exec_with_output(
             &params.netns_name,
@@ -203,10 +204,17 @@ impl Piapf {
         if let Some(cb) = &params.callback {
             let refresh_response = NetworkNamespace::exec_with_output(
                 &params.netns_name,
-                &[&cb, &params.port.to_string()],
+                &[cb, &params.port.to_string()],
             )?;
             if !refresh_response.status.success() {
-                log::info!("Callback script was unsuccessful!");
+                log::error!(
+                    "Port forwarding callback script was unsuccessful!: stdout: {:?}, stderr: {:?}, exit code: {}",
+                    String::from_utf8(refresh_response.stdout),
+                    String::from_utf8(refresh_response.stderr),
+                    refresh_response.status
+                );
+            } else if let Ok(out) = String::from_utf8(refresh_response.stdout) {
+                println!("{}", out);
             }
         }
 


### PR DESCRIPTION
Fixes port forwarding when using Wireguard with ProtonVPN as custom provider config files, e.g.:

```bash
$ vopono -v exec --custom ~/hostname-RO-9.conf --protocol wireguard --provider custom --custom-port-forwarding protonvpn --port-forwarding-callback ./print_first_arg.sh firefox-developer-edition
```

Fixes Wireguard part of issue #247 