### PR TITLE
Fix network interface parsing from config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.10.9"
+version = "0.10.10"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/src/list.rs
+++ b/src/list.rs
@@ -23,9 +23,8 @@ pub fn print_applications() -> anyhow::Result<()> {
         let now = Utc::now();
         for ns in keys {
             for lock in namespaces.get(ns).unwrap() {
-                let naive = NaiveDateTime::from_timestamp_opt(lock.start as i64, 0)
+                let datetime = DateTime::from_timestamp(lock.start as i64, 0)
                     .ok_or_else(|| anyhow!("Timestamp parsing failed"))?;
-                let datetime: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, Utc);
                 let diff = now - datetime;
                 println!(
                     "{}\t{}\t{}\t{}\t{}",
@@ -62,9 +61,8 @@ pub fn print_namespaces() -> anyhow::Result<()> {
                 .map(|x| x.start)
                 .min()
                 .unwrap();
-            let naive = NaiveDateTime::from_timestamp_opt(min_time as i64, 0)
+            let datetime = DateTime::from_timestamp(min_time as i64, 0)
                 .ok_or_else(|| anyhow!("Timestamp parsing failed"))?;
-            let datetime: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, Utc);
             let diff = now - datetime;
             println!(
                 "{}\t{}\t{}\t{}\t{}",

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono_core"
 description = "Library code for running VPN connections in network namespaces"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 license = "GPL-3.0-or-later"
@@ -25,7 +25,7 @@ walkdir = "2"
 rand = "0.8"
 toml = "0.8"
 ipnet = { version = "2", features = ["serde"] }
-reqwest = { default-features = false, version = "0.11", features = [
+reqwest = { default-features = false, version = "0.12", features = [
     "blocking",
     "json",
     "rustls-tls",


### PR DESCRIPTION
Fixes issue #254 

Interface must be parsed as string explicitly and then converted if present