### PR TITLE
docs: make it more clear that one can self host

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ lynx all running through different VPN connections:
 | HMA (HideMyAss)         | ✅              | ❌                |
 | AirVPN                  | ✅              | ❌                |
 | Cloudflare Warp\*\*\*\* | ❌              | ❌                |
+| Self host (--custom)    | ✅              | ✅                |
 
 \* Port forwarding supported with the `--port-forwarding` option and `--port-forwarding-callback` to run a command when the port is refreshed.
 


### PR DESCRIPTION
I've used vopono several times but somehow I've missed that it can be used with your own OpenVPN server

I think putting something like a "Self" provider in the table would make it a lot more clear. Open to edits on the specific language but I definitely think it should be in the table somewhere because some people only look at tables