### PR TITLE
Fix Cloudflare Warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ argument.
 
 
 \*\*\*\* Cloudflare Warp uses its own protocol. Set both the provider and
-protocol to `warp`. Note you must first register with `sudo warp-cli register` and then run it once with `sudo warp-svc` and `sudo warp-cli connect` outside of vopono.
-Please verify this works first before trying it with vopono. Note there
-may also be issues with Warp overriding the DNS settings.
+protocol to `warp`. Note you must first register with `sudo warp-cli registration new` and then run it once with `sudo warp-svc` and `sudo warp-cli connect` and `sudo warp-cli debug connectivity-check disable` outside of vopono - then kill `sudo warp-svc` without running `sudo warp-cli disconnect` so it will auto-connect when run.
+Please verify this works first before trying it with vopono. 
 
 
 ## Usage

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -619,20 +619,57 @@ Note the usual `-o` / `--open-ports` argument has no effect here as we only know
 
 ### Cloudflare Warp
 
+Note Cloudflare Warp does **not** anonymise you - it is solely for
+different routing and DNS servers. However, it does provide routing and
+encryption vs. your ISP.
+
 Cloudflare Warp users must first register with Warp via the CLI client:
 ```
-$ sudo warp-cli register
+$ sudo warp-svc
+$ sudo warp-cli registration new
 ```
+
 And then run Warp once to enable automatic connection on service
-availability:
+availability and disable the connection check:
 ```
 $ sudo warp-svc
 $ sudo warp-cli connect
+$ sudo warp-cli debug connectivity-check disable
 ```
+
 You can then kill `warp-svc` and run it via vopono:
 ```
 $ vopono -v exec --no-killswitch --provider warp --protocol warp firefox-developer-edition
 ```
+
+Note that disabling the connectivity check and killing all other warp-svc instances is necessary for it to work in vopono.
+
+#### Verifying the Warp connection
+
+You can test the connection at https://cloudflare.com/cdn-cgi/trace
+For example for a running vopono namespace:
+```
+$ sudo ip netns exec vo_wp_warp curl "https://cloudflare.com/cdn-cgi/trace"
+fl=xxx
+h=cloudflare.com
+ip=xxx
+ts=xxx
+visit_scheme=https
+uag=curl/8.13.0
+colo=MAD
+sliver=none
+http=http/2
+loc=XX
+tls=TLSv1.3
+sni=plaintext
+warp=on
+gateway=off
+rbi=off
+kex=xxx
+```
+Where warp=on means you are routing via Cloudflare Warp.
+
+You can also check for "Using DNS over WARP" at https://one.one.one.one/help/
 
 ## VPN Provider limitations
 

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -25,8 +25,8 @@ walkdir = "2"
 # Stuck on rand 0.6 due to x25519-dalek:
 # https://github.com/dalek-cryptography/curve25519-dalek/issues/731
 # https://github.com/dalek-cryptography/curve25519-dalek/pull/729
-rand = "0.6"
-rand_core = { version = "0.6", features = ["getrandom"] }
+rand = "0.6.4"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 toml = "0.8"
 ipnet = { version = "2", features = ["serde"] }
 reqwest = { default-features = false, version = "0.12", features = [
@@ -37,7 +37,6 @@ reqwest = { default-features = false, version = "0.12", features = [
 sysinfo = "0.34"
 base64 = "0.22"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
-
 strum = "0.27"
 strum_macros = "0.27"
 zip = "2"
@@ -51,3 +50,4 @@ chrono = "0.4"
 json = "0.12"
 shell-words = "1"
 dns-lookup = "2"
+libc = "0.2"


### PR DESCRIPTION
Fixes #235 (original PR was #237 )

Fix Cloudflare Warp by re-directing the write to /etc/resolv.conf to the netns resolv.conf at /etc/netns/vo_wp_warp/resolv.conf

This is very hacky, but it works.

Note it is also necessary to disable Warp's connectivity check: i.e. a new user should first run the following on the host, outside of vopono:
```
$ sudo warp-svc
$ sudo warp-cli registration new
$ sudo warp-cli connect
$ sudo warp-cli debug connectivity-check disable
```
And then kill warp-svc directly e.g. with ctrl+C