### PR TITLE
Read MTU from Wireguard config when present

### DIFF
--- a/vopono_core/src/config/providers/azirevpn/wireguard.rs
+++ b/vopono_core/src/config/providers/azirevpn/wireguard.rs
@@ -67,6 +67,7 @@ impl AzireVPN {
             private_key: keypair.private.clone(),
             address: vec![v4_net],
             dns: Some(device_response_data.dns),
+            mtu: Some(1420.to_string()),
         };
 
         Ok(interface)
@@ -101,6 +102,7 @@ impl AzireVPN {
             private_key: keypair.private.clone(),
             address: vec![v4_net],
             dns: Some(device.dns.clone()),
+            mtu: Some(1420.to_string()),
         };
 
         Ok(interface)
@@ -225,6 +227,7 @@ impl WireguardProvider for AzireVPN {
                         private_key,
                         address: vec![v4_net],
                         dns: Some(existing_device.dns.clone()),
+                        mtu: Some(1420.to_string()),
                     }
                 }
             }

--- a/vopono_core/src/config/providers/ivpn/wireguard.rs
+++ b/vopono_core/src/config/providers/ivpn/wireguard.rs
@@ -179,6 +179,7 @@ impl WireguardProvider for IVPN {
             private_key: keypair.private,
             address: vec![ipnet],
             dns: Some(vec![IpAddr::from(dns)]),
+            mtu: Some(1420.to_string()),
         };
 
         let port = request_port(uiclient)?;

--- a/vopono_core/src/config/providers/mozilla/wireguard.rs
+++ b/vopono_core/src/config/providers/mozilla/wireguard.rs
@@ -172,6 +172,7 @@ impl WireguardProvider for MozillaVPN {
                 IpNet::from(wg_peer.ipv6_address),
             ],
             dns: Some(vec![IpAddr::from(dns)]),
+            mtu: Some(1420.to_string()),
         };
 
         let port = request_port(uiclient)?;

--- a/vopono_core/src/config/providers/mullvad/wireguard.rs
+++ b/vopono_core/src/config/providers/mullvad/wireguard.rs
@@ -252,6 +252,7 @@ impl WireguardProvider for Mullvad {
             private_key: keypair.private.clone(),
             address: vec![ipv4_net, ipv6_net],
             dns: Some(vec![IpAddr::from(dns)]),
+            mtu: Some(1420.to_string()),
         };
 
         let port = request_port(uiclient)?;

--- a/vopono_core/src/config/providers/pia/wireguard.rs
+++ b/vopono_core/src/config/providers/pia/wireguard.rs
@@ -207,6 +207,7 @@ impl WireguardProvider for PrivateInternetAccess {
             private_key: keypair.private.clone(),
             address: vec![IpNet::new(Ipv4Addr::LOCALHOST.into(), 32)?],
             dns: Some(vec![Ipv4Addr::LOCALHOST.into()]),
+            mtu: Some(1420.to_string()),
         };
 
         let allowed_ips = vec![IpNet::from_str("0.0.0.0/0")?];


### PR DESCRIPTION
Default is 1420 otherwise.

Note atm we set 1420 in all sync-generated configs, this should be swapped for the actual provider-preferred value when possible.

Addresses part of issue #306 