### PR TITLE
Fix regression where vopono env vars not set

### DIFF
--- a/vopono_core/src/network/application_wrapper.rs
+++ b/vopono_core/src/network/application_wrapper.rs
@@ -1,7 +1,12 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use log::debug;
 
 use super::{netns::NetworkNamespace, port_forwarding::Forwarder};
-use crate::util::{get_all_running_process_names, parse_command_str};
+use crate::util::{env_vars::set_env_vars, get_all_running_process_names, parse_command_str};
 
 pub struct ApplicationWrapper {
     pub handle: std::process::Child,
@@ -43,8 +48,8 @@ impl ApplicationWrapper {
 
         let app_vec_ptrs: Vec<&str> = app_vec.iter().map(|s| s.as_str()).collect();
 
-        let handle = NetworkNamespace::exec_no_block(
-            &netns.name,
+        let handle = Self::run_with_env_in_netns(
+            netns,
             app_vec_ptrs.as_slice(),
             user,
             group,
@@ -52,6 +57,7 @@ impl ApplicationWrapper {
             false,
             false,
             working_directory,
+            port_forwarding.as_deref(),
         )?;
         Ok(Self {
             handle,
@@ -62,5 +68,65 @@ impl ApplicationWrapper {
     pub fn wait_with_output(self) -> anyhow::Result<std::process::Output> {
         let output = self.handle.wait_with_output()?;
         Ok(output)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_with_env_in_netns(
+        netns: &NetworkNamespace,
+        command: &[&str],
+        user: Option<String>,
+        group: Option<String>,
+        silent: bool,
+        capture_output: bool,
+        capture_input: bool,
+        set_dir: Option<PathBuf>,
+        forwarder: Option<&dyn Forwarder>,
+    ) -> anyhow::Result<std::process::Child> {
+        let mut handle = Command::new("ip");
+        set_env_vars(netns, forwarder, &mut handle);
+        handle.args(["netns", "exec", netns.name.as_str()]);
+        if let Some(cdir) = set_dir {
+            handle.current_dir(cdir);
+        }
+
+        let mut sudo_args = Vec::new();
+        if let Some(ref user) = user {
+            sudo_args.push("--user");
+            sudo_args.push(user);
+        }
+        if let Some(ref group) = group {
+            sudo_args.push("--group");
+            sudo_args.push(group);
+        }
+
+        let sudo_string = if !sudo_args.is_empty() {
+            let mut args = vec!["sudo", "--preserve-env"];
+            args.append(&mut sudo_args);
+            handle.args(args.clone());
+            Some(format!(" {}", args.join(" ")))
+        } else {
+            None
+        };
+
+        if silent {
+            handle.stdout(Stdio::null());
+            handle.stderr(Stdio::null());
+        }
+        if capture_output {
+            handle.stdout(Stdio::piped());
+            handle.stderr(Stdio::piped());
+        }
+        if capture_input {
+            handle.stdin(Stdio::piped());
+        }
+
+        debug!(
+            "ip netns exec {}{} {}",
+            netns.name,
+            sudo_string.unwrap_or_else(|| String::from("")),
+            command.join(" ")
+        );
+        let handle = handle.args(command).spawn()?;
+        Ok(handle)
     }
 }

--- a/vopono_core/src/util/env_vars.rs
+++ b/vopono_core/src/util/env_vars.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+use log::{debug, warn};
+
+use crate::network::{netns::NetworkNamespace, port_forwarding::Forwarder};
+
+pub fn set_env_vars(ns: &NetworkNamespace, forwarder: Option<&dyn Forwarder>, cmd: &mut Command) {
+    // Temporarily set env var referring to this network namespace IP
+    // for the PostUp script and the application:
+
+    if which::which("pactl").is_ok() {
+        let pa = crate::util::pulseaudio::get_pulseaudio_server();
+        if let Ok(pa) = pa {
+            cmd.env("PULSE_SERVER", &pa);
+            debug!("Setting PULSE_SERVER to {}", &pa);
+        } else if let Err(e) = pa {
+            warn!("Could not get PULSE_SERVER: {e:?}");
+        } else {
+            warn!("Could not parse PULSE_SERVER from pactl info output: {pa:?}",);
+        }
+    } else {
+        debug!("pactl not found, will not set PULSE_SERVER");
+    }
+
+    if let Some(ref ns_ip) = ns.veth_pair_ips {
+        cmd.env("VOPONO_NS_IP", ns_ip.namespace_ip.to_string());
+        cmd.env("VOPONO_HOST_IP", ns_ip.host_ip.to_string());
+    }
+
+    cmd.env("VOPONO_NS", &ns.name);
+
+    // TODO: Do we want to provide -o open ports too?
+    if let Some(f) = forwarder.as_ref() {
+        cmd.env("VOPONO_FORWARDED_PORT", f.forwarded_port().to_string());
+    }
+}

--- a/vopono_core/src/util/mod.rs
+++ b/vopono_core/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod country_map;
+pub mod env_vars;
 pub mod open_hosts;
 pub mod open_ports;
 pub mod pulseaudio;


### PR DESCRIPTION
The change to set env vars for each spawned command separately to avoid the now unsafe global set_env accidentally meant they were not set for the application run by vopono itself in the netns, and so were not present for scripts there.