### PR TITLE
Set iptables to be the default firewall (if present) to avoid issues …

### DIFF
--- a/vopono_core/src/util/mod.rs
+++ b/vopono_core/src/util/mod.rs
@@ -458,10 +458,10 @@ pub fn get_config_file_protocol(config_file: &Path) -> anyhow::Result<Protocol> 
 }
 
 pub fn get_firewall() -> anyhow::Result<Firewall> {
-    if which("nft").is_ok() {
-        Ok(Firewall::NfTables)
-    } else if which("iptables").is_ok() {
+    if which("iptables").is_ok() {
         Ok(Firewall::IpTables)
+    } else if which("nft").is_ok() {
+        Ok(Firewall::NfTables)
     } else {
         Err(anyhow!("Neither nftables nor iptables is installed!"))
     }


### PR DESCRIPTION
…with Docker


Docker sets a load of iptables rules which will interfere with our nftables ones regardless of the order in which they run (due to the default drop in FORWARD).

The only simple solution is to just set our rules in iptables in that case.