### PR TITLE
Set Mullvad DNS correctly for Wireguard

### DIFF
--- a/vopono_core/src/config/providers/mullvad/openvpn.rs
+++ b/vopono_core/src/config/providers/mullvad/openvpn.rs
@@ -45,7 +45,8 @@ impl Mullvad {
 
 impl OpenVpnProvider for Mullvad {
     fn provider_dns(&self) -> Option<Vec<IpAddr>> {
-        // TODO: Fix this with endpoint-specific DNS - unfortunately this is not simply the first address in the IpNet
+        // This gets overridden by DNS from server at runtime anyway
+        // Used only for initial request
         Some(vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
     }
 

--- a/vopono_core/src/config/providers/mullvad/wireguard.rs
+++ b/vopono_core/src/config/providers/mullvad/wireguard.rs
@@ -247,8 +247,7 @@ impl WireguardProvider for Mullvad {
 
         debug!("Chosen keypair: {keypair:?}");
 
-        // TODO: Fix this with endpoint-specific DNS - unfortunately this is not simply the first address in the IpNet
-        let dns = std::net::Ipv4Addr::new(8, 8, 8, 8);
+        let dns = std::net::Ipv4Addr::new(10, 64, 0, 1);
 
         let interface = WireguardInterface {
             private_key: keypair.private.clone(),


### PR DESCRIPTION
Use Mullvad's DNS with Wireguard