### PR TITLE
Fix AzireVPN parsing

### DIFF
--- a/vopono_core/src/config/providers/azirevpn/mod.rs
+++ b/vopono_core/src/config/providers/azirevpn/mod.rs
@@ -88,7 +88,9 @@ impl ConfigurationChoice for ExistingDevicesResponse {
             .iter()
             .filter_map(|x| {
                 // Filter out entries with null names
-                x.device_name.as_ref().map(|name| format!("{}, {}", name, x.ipv4_address))
+                x.device_name
+                    .as_ref()
+                    .map(|name| format!("{}, {}", name, x.ipv4_address))
             })
             .collect();
         v.push("generate a new keypair".to_string());

--- a/vopono_core/src/config/providers/azirevpn/mod.rs
+++ b/vopono_core/src/config/providers/azirevpn/mod.rs
@@ -67,7 +67,7 @@ struct ExistingDeviceResponseData {
     ipv6_address: String,
     ipv6_netmask: u8,
     dns: Vec<IpAddr>,
-    device_name: String,
+    device_name: Option<String>,
     keys: Vec<KeyResponse>,
 }
 
@@ -86,7 +86,10 @@ impl ConfigurationChoice for ExistingDevicesResponse {
         let mut v: Vec<String> = self
             .data
             .iter()
-            .map(|x| format!("{}, {}", x.device_name, x.ipv4_address))
+            .filter_map(|x| {
+                // Filter out entries with null names
+                x.device_name.as_ref().map(|name| format!("{}, {}", name, x.ipv4_address))
+            })
             .collect();
         v.push("generate a new keypair".to_string());
         Some(v)

--- a/vopono_core/src/network/host_masquerade.rs
+++ b/vopono_core/src/network/host_masquerade.rs
@@ -162,7 +162,7 @@ impl Drop for HostMasquerade {
                             "-j",
                             "MASQUERADE",
                         ])
-                        .unwrap_or_else(|e| log::warn!("Failed to delete iptables rule: {}", e));
+                        .unwrap_or_else(|e| log::warn!("Failed to delete iptables rule: {e}"));
                     }
                     if let Some(ref mask) = self.ipv6_mask {
                         sudo_command(&[
@@ -178,13 +178,13 @@ impl Drop for HostMasquerade {
                             "-j",
                             "MASQUERADE",
                         ])
-                        .unwrap_or_else(|e| log::warn!("Failed to delete ip6tables rule: {}", e));
+                        .unwrap_or_else(|e| log::warn!("Failed to delete ip6tables rule: {e}"));
                     }
                 }
                 Firewall::NfTables => {
                     // The entire table is deleted, removing all rules within it.
                     sudo_command(&["nft", "delete", "table", "inet", "vopono_nat"]).unwrap_or_else(
-                        |e| log::warn!("Failed to delete nftables table vopono_nat: {}", e),
+                        |e| log::warn!("Failed to delete nftables table vopono_nat: {e}"),
                     );
                 }
             }

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -334,12 +334,8 @@ impl NetworkNamespace {
             )
             .with_context(|| "Failed to add IPv6 default route in netns")?;
 
-            info!(
-                "IPv6 address of namespace as seen from host: {ipv6_ns_ip_str}"
-            );
-            info!(
-                "IPv6 address of host as seen from namespace: {ipv6_host_ip_str}"
-            );
+            info!("IPv6 address of namespace as seen from host: {ipv6_ns_ip_str}");
+            info!("IPv6 address of host as seen from namespace: {ipv6_host_ip_str}");
 
             veth_ips.ipv6 = Some(IpPair {
                 host_ip: ipv6_host_ip_str.parse()?,

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -272,12 +272,12 @@ impl NetworkNamespace {
 
         if !disable_ipv6 {
             // Using Unique Local Addresses (ULA) fd42:4242:{subnet}::/64
-            let ipv6_host_ip_str = format!("fd42:4242:{:x}::1", target_subnet);
-            let ipv6_ns_ip_str = format!("fd42:4242:{:x}::2", target_subnet);
+            let ipv6_host_ip_str = format!("fd42:4242:{target_subnet:x}::1");
+            let ipv6_ns_ip_str = format!("fd42:4242:{target_subnet:x}::2");
             let ipv6_host_ip_cidr = format!("{ipv6_host_ip_str}/64");
             let ipv6_ns_ip_cidr = format!("{ipv6_ns_ip_str}/64");
 
-            let ipv6_sysctl_path = format!("net.ipv6.conf.{}.disable_ipv6", veth_dest);
+            let ipv6_sysctl_path = format!("net.ipv6.conf.{veth_dest}.disable_ipv6");
             let sysctl_output = std::process::Command::new("sysctl")
                 .args(["-n", &ipv6_sysctl_path])
                 .output();
@@ -286,28 +286,25 @@ impl NetworkNamespace {
                     let value = String::from_utf8_lossy(&output.stdout);
                     if value.trim() == "1" {
                         log::warn!(
-                            "IPv6 is currently disabled for interface {}, enabling it now",
-                            veth_dest
+                            "IPv6 is currently disabled for interface {veth_dest}, enabling it now"
                         );
                     }
                 }
                 Ok(output) => {
                     let value = String::from_utf8_lossy(&output.stdout);
                     log::warn!(
-                        "Failed to check IPv6 status for {}: sysctl returned non-zero exit code, output: {}",
-                        veth_dest,
-                        value
+                        "Failed to check IPv6 status for {veth_dest}: sysctl returned non-zero exit code, output: {value}"
                     );
                 }
                 Err(e) => {
-                    log::warn!("Failed to check IPv6 status for {}: {}", veth_dest, e);
+                    log::warn!("Failed to check IPv6 status for {veth_dest}: {e}");
                 }
             }
-            log::debug!("Enabling IPv6 for {}", veth_dest);
+            log::debug!("Enabling IPv6 for {veth_dest}");
             sudo_command(&[
                 "sysctl",
                 "-w",
-                &format!("net.ipv6.conf.{}.disable_ipv6=0", veth_dest),
+                &format!("net.ipv6.conf.{veth_dest}.disable_ipv6=0"),
             ])?;
 
             sudo_command(&["ip", "addr", "add", &ipv6_host_ip_cidr, "dev", veth_dest])
@@ -338,12 +335,10 @@ impl NetworkNamespace {
             .with_context(|| "Failed to add IPv6 default route in netns")?;
 
             info!(
-                "IPv6 address of namespace as seen from host: {}",
-                ipv6_ns_ip_str
+                "IPv6 address of namespace as seen from host: {ipv6_ns_ip_str}"
             );
             info!(
-                "IPv6 address of host as seen from namespace: {}",
-                ipv6_host_ip_str
+                "IPv6 address of host as seen from namespace: {ipv6_host_ip_str}"
             );
 
             veth_ips.ipv6 = Some(IpPair {
@@ -610,12 +605,12 @@ impl NetworkNamespace {
         let ipv4_mask = veth_ips
             .ipv4
             .as_ref()
-            .map(|_| format!("10.200.{}.0/24", target_subnet));
+            .map(|_| format!("10.200.{target_subnet}.0/24"));
 
         let ipv6_mask = veth_ips
             .ipv6
             .as_ref()
-            .map(|_| format!("fd42:4242:{:x}::/64", target_subnet)); // Will be None if IPv6 disabled
+            .map(|_| format!("fd42:4242:{target_subnet:x}::/64")); // Will be None if IPv6 disabled
 
         self.host_masquerade = Some(HostMasquerade::add_masquerade_rule(
             ipv4_mask, ipv6_mask, interface, firewall,

--- a/vopono_core/src/network/wireguard.rs
+++ b/vopono_core/src/network/wireguard.rs
@@ -113,9 +113,7 @@ impl Wireguard {
                 "ip6"
             };
 
-            debug!(
-                "Opening firewall for Wireguard peer (out): {peer_ip_str} dport {peer_port}"
-            );
+            debug!("Opening firewall for Wireguard peer (out): {peer_ip_str} dport {peer_port}");
             // Allow the initial OUTGOING connection packet.
             NetworkNamespace::exec(
                 &namespace.name,
@@ -137,9 +135,7 @@ impl Wireguard {
                 ],
             )?;
 
-            debug!(
-                "Opening firewall for Wireguard peer (in): {peer_ip_str} sport {peer_port}"
-            );
+            debug!("Opening firewall for Wireguard peer (in): {peer_ip_str} sport {peer_port}");
             // Allow the server's INCOMING reply packet.
             NetworkNamespace::exec(
                 &namespace.name,

--- a/vopono_core/src/network/wireguard.rs
+++ b/vopono_core/src/network/wireguard.rs
@@ -114,8 +114,7 @@ impl Wireguard {
             };
 
             debug!(
-                "Opening firewall for Wireguard peer (out): {} dport {}",
-                peer_ip_str, peer_port
+                "Opening firewall for Wireguard peer (out): {peer_ip_str} dport {peer_port}"
             );
             // Allow the initial OUTGOING connection packet.
             NetworkNamespace::exec(
@@ -139,8 +138,7 @@ impl Wireguard {
             )?;
 
             debug!(
-                "Opening firewall for Wireguard peer (in): {} sport {}",
-                peer_ip_str, peer_port
+                "Opening firewall for Wireguard peer (in): {peer_ip_str} sport {peer_port}"
             );
             // Allow the server's INCOMING reply packet.
             NetworkNamespace::exec(

--- a/vopono_core/src/network/wireguard_config.rs
+++ b/vopono_core/src/network/wireguard_config.rs
@@ -148,16 +148,16 @@ impl Display for WireguardConfig {
             .map(|a| a.to_string())
             .collect::<Vec<String>>()
             .join(", ");
-        writeln!(f, "Address = {}", addresses)?;
+        writeln!(f, "Address = {addresses}")?;
 
         if let Some(mtu) = &self.interface.mtu {
-            writeln!(f, "MTU = {}", mtu)?;
+            writeln!(f, "MTU = {mtu}")?;
         }
 
         // Write each DNS server on a new line, which is idiomatic
         if let Some(dns_servers) = &self.interface.dns {
             for dns in dns_servers {
-                writeln!(f, "DNS = {}", dns)?;
+                writeln!(f, "DNS = {dns}")?;
             }
         }
 
@@ -172,12 +172,12 @@ impl Display for WireguardConfig {
             .map(|a| a.to_string())
             .collect::<Vec<String>>()
             .join(", ");
-        writeln!(f, "AllowedIPs = {}", allowed_ips)?;
+        writeln!(f, "AllowedIPs = {allowed_ips}")?;
 
         writeln!(f, "Endpoint = {}", self.peer.endpoint)?;
 
         if let Some(keepalive) = &self.peer.keepalive {
-            writeln!(f, "PersistentKeepalive = {}", keepalive)?;
+            writeln!(f, "PersistentKeepalive = {keepalive}")?;
         }
 
         Ok(())
@@ -323,7 +323,7 @@ impl FromStr for WireguardConfig {
                                 dns_servers.extend(value.split(',').map(|s| s.trim().to_string()))
                             }
                             "MTU" => mtu = Some(value.to_string()),
-                            _ => warn!("Unknown key in [Interface] section: {}", key),
+                            _ => warn!("Unknown key in [Interface] section: {key}"),
                         }
                     }
 
@@ -365,7 +365,7 @@ impl FromStr for WireguardConfig {
                             }
                             "Endpoint" => endpoint = Some(value.to_string()),
                             "PersistentKeepalive" => keepalive = Some(value.to_string()),
-                            _ => warn!("Unknown key in [Peer] section: {}", key),
+                            _ => warn!("Unknown key in [Peer] section: {key}"),
                         }
                     }
 
@@ -387,7 +387,7 @@ impl FromStr for WireguardConfig {
                         keepalive,
                     });
                 }
-                _ => warn!("Unknown section in config: {}", section_name),
+                _ => warn!("Unknown section in config: {section_name}"),
             }
         }
 

--- a/vopono_core/src/util/env_vars.rs
+++ b/vopono_core/src/util/env_vars.rs
@@ -15,7 +15,7 @@ pub fn get_host_env_vars() -> HashMap<String, String> {
                 env_vars.insert("PULSE_SERVER".to_string(), pa);
             }
             Err(e) => {
-                warn!("Could not get PULSE_SERVER from host: {:?}", e);
+                warn!("Could not get PULSE_SERVER from host: {e:?}");
             }
         }
     } else {


### PR DESCRIPTION
Fixes new API calls parsing added in PR #305 for issue #294 for `vopono sync`

Note atm we ignore devices with null names which can happen if their access tokens have been deleted separately.