### PR TITLE
Introduce daemon for sudo-less operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root binary crate `vopono/`: entry at `src/main.rs`; CLI modules in `src/*.rs`.
+- Core library crate `vopono_core/`: main code under `src/` with `config/`, `network/`, and `util/` modules. Add providers in `vopono_core/src/config/providers/`.
+- Docs and assets: `README.md`, `USERGUIDE.md`, images in `logos/`, CI in `.github/workflows/`.
+- User config lives in `~/.config/vopono/` (e.g., `config.toml`).
+
+## Build, Test, and Development Commands
+- Build: `cargo build` (workspace by default).
+- Run tests: `cargo test --workspace`.
+- Lint/format (CI-enforced):
+  - `cargo fmt --all`
+  - `cargo clippy --all-features --all-targets -- -D warnings`
+- Run locally (example):
+  - `cargo run -- exec --provider mullvad --server se firefox`
+  - Start root daemon (recommended for local runs): `sudo -E cargo run -- daemon`
+    - With the daemon running, non-root `cargo run -- exec ...` forwards over `/run/vopono.sock`.
+- Install from repo: `./install.sh` (invokes `cargo install`).
+
+## Coding Style & Naming Conventions
+- Rust 2024 edition; use `rustfmt` defaults (4-space indent). Keep code simple and modular.
+- Names: modules/files `snake_case`; functions/vars `snake_case`; types/traits/enums `PascalCase`.
+- Errors: prefer `anyhow::Result<T>` and propagate with `?`.
+- Logging via `log`/`pretty_env_logger`; avoid println for non-user output.
+
+## Testing Guidelines
+- Place unit tests next to code (`#[cfg(test)] mod tests { ... }`). Most tests live in `vopono_core` (e.g., parsing and config).
+- Add tests for new providers, parsers, and utilities; keep them deterministic and offline.
+- Run `cargo test --workspace` before pushing. CI runs fmt, clippy, and tests on PRs.
+
+## Commit & Pull Request Guidelines
+- Commits: concise, imperative mood (e.g., "Add IPv6 endpoint support"). Reference issues/PRs when relevant (e.g., "Fix #123", "(#456)").
+- PRs should include: clear description of the change, rationale, CLI examples if applicable, and tests for new logic. Confirm fmt, clippy, and tests pass locally.
+- Keep PRs focused; avoid unrelated refactors and churn.
+
+## Security & Configuration Tips
+- Run `vopono` as your user; it escalates privileges only when required. Avoid running the whole session as root.
+- External deps: install `wireguard-tools` and/or `openvpn` when testing respective flows.
+- Treat files under `~/.config/vopono/` as sensitive (may contain credentials). Do not commit real credentials.
+
+## Agent-Specific Instructions
+- Keep changes minimal and aligned with existing modules. Prefer provider logic in `vopono_core`; keep CLI glue in `src/`.
+- Do not rename files or alter public APIs without prior discussion.
+ - Daemon mode lives in `src/daemon.rs` and is started via `vopono daemon` (root). The CLI attempts to forward `exec` to the daemon when available.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,16 @@ signal-hook = "0.3"
 walkdir = "2"
 chrono = "0.4"
 bs58 = "0.5"
-nix = { version = "0.30", features = ["signal", "process"] }
+nix = { version = "0.30", features = ["signal", "process", "socket", "uio", "mount", "term"] }
 config = "0.15"
-basic_tcp_proxy = "0.3.2"
+basic_tcp_proxy = "0.3"
+serde = { version = "1", features = ["derive", "std"] }
 strum = "0.27"
 strum_macros = "0.27"
 shellexpand = { version = "3", features = ["full"] }
 shell-words = "1"
+interprocess = "2"
+bincode = { version = "2", features = ["serde"] }
 
 [package.metadata.rpm]
 package = "vopono"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ You should run vopono as your own user (not using sudo) as it will
 handle privilege escalation where necessary. For more details around
 running as a systemd service, etc. see the [User Guide](USERGUIDE.md).
 
+### Daemon Mode
+
+For a smoother experience, run the privileged root daemon and keep using `vopono` as your normal user. The CLI automatically forwards `exec` requests to the daemon if it’s running.
+
+- Start once at boot via systemd: `sudo systemctl enable --now vopono-daemon`
+- Or run manually as root: `sudo vopono daemon`
+- Then use vopono normally as your user: `vopono exec --provider mullvad --server se firefox`
+
+See USERGUIDE.md for a ready‑to‑copy systemd unit.
+
 vopono can handle up to 255 separate network namespaces (i.e. different VPN server
 connections - if your VPN provider allows it). Commands launched with
 the same server prefix and VPN provider will share the same network

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,397 @@
+use crate::SOCKET_PATH;
+use crate::args::ExecCommand;
+use crate::exec::execute_as_daemon_with_stdio;
+use anyhow::{Context, anyhow};
+use interprocess::TryClone;
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::{ListenerOptions, ToFsName};
+use interprocess::os::unix::local_socket::FilesystemUdSocket;
+use log::{error, info};
+use nix::pty::openpty;
+use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
+use nix::unistd::isatty as nix_isatty;
+use nix::unistd::{Gid, Group, Uid, User};
+use nix::{
+    cmsg_space,
+    sys::socket::{ControlMessageOwned, MsgFlags, recvmsg},
+};
+use serde::{Deserialize, Serialize};
+use signal_hook::{
+    consts::{SIGINT, SIGQUIT, SIGTERM},
+    iterator::Signals,
+};
+use std::io::IoSliceMut;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, RawFd};
+use std::os::fd::{BorrowedFd, IntoRawFd, OwnedFd};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+
+// Do not change user's terminal modes; rely on PTY + signal/control forwarding
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DaemonRequest {
+    Execute(ExecCommand),
+    Control(DaemonControl),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum DaemonControl {
+    Signal(i32),
+}
+
+// Note: Output is bridged via passed file descriptors; no streaming over the socket.
+
+/// Starts the vopono daemon and listens for client connections.
+pub fn start() -> anyhow::Result<()> {
+    // Clean up any stale socket file from a previous unclean shutdown.
+    let _ = std::fs::remove_file(SOCKET_PATH);
+
+    // Set up a signal handler to clean up the socket file on exit.
+    let mut signals = Signals::new([SIGTERM, SIGINT, SIGQUIT])?;
+    let socket_path = SOCKET_PATH.to_string();
+    std::thread::spawn(move || {
+        // Block until the first signal is received, then exit.
+        if let Some(signal) = signals.forever().next() {
+            info!(
+                "Received signal {}, cleaning up socket and exiting.",
+                signal
+            );
+            let _ = std::fs::remove_file(&socket_path);
+            std::process::exit(0);
+        }
+    });
+
+    let name = SOCKET_PATH.to_fs_name::<FilesystemUdSocket>()?;
+
+    let listener = ListenerOptions::new()
+        .name(name)
+        .create_sync()
+        .with_context(|| format!("Failed to bind to socket at {}", SOCKET_PATH))?;
+
+    let mut perms = std::fs::metadata(SOCKET_PATH)?.permissions();
+    // Set permissions to 777 to allow any user to connect to the daemon socket.
+    // The daemon itself will then check the user's credentials upon connection.
+    perms.set_mode(0o777);
+    std::fs::set_permissions(SOCKET_PATH, perms)?;
+    info!("Daemon listening on {}", SOCKET_PATH);
+
+    for conn in listener.incoming().filter_map(handle_accept_error) {
+        thread::spawn(move || {
+            if let Err(e) = handle_client(conn) {
+                error!("Error handling client: {}", e);
+            }
+        });
+    }
+    Ok(())
+}
+
+fn handle_accept_error(
+    conn: Result<LocalSocketStream, std::io::Error>,
+) -> Option<LocalSocketStream> {
+    match conn {
+        Ok(c) => Some(c),
+        Err(e) => {
+            error!("Failed to accept connection: {}", e);
+            None
+        }
+    }
+}
+
+/// Get peer credentials from a Unix domain socket
+fn get_peer_credentials(stream: &LocalSocketStream) -> anyhow::Result<(Uid, Gid)> {
+    let LocalSocketStream::UdSocket(s) = stream;
+    let creds =
+        getsockopt(&s.as_fd(), PeerCredentials).context("Failed to get peer credentials")?;
+    Ok((Uid::from_raw(creds.uid()), Gid::from_raw(creds.gid())))
+}
+
+/// Handles a single client connection.
+fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
+    let (uid, gid) = get_peer_credentials(&conn)?;
+    let user = User::from_uid(uid)?.ok_or(anyhow!("Invalid UID"))?;
+    let group = Group::from_gid(gid)?.ok_or(anyhow!("Invalid GID"))?;
+    info!(
+        "Accepted connection from user='{}' (uid={}), group='{}' (gid={})",
+        user.name, uid, group.name, gid
+    );
+
+    // Read a framed request (length-prefixed u32 then payload)
+    let mut len_bytes = [0u8; 4];
+    conn.read_exact(&mut len_bytes)?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    let mut buffer = vec![0u8; len];
+    conn.read_exact(&mut buffer)?;
+    let (request, _len): (DaemonRequest, usize) =
+        bincode::serde::decode_from_slice(&buffer, bincode::config::standard())?;
+
+    // Receive stdin, stdout, stderr FDs via SCM_RIGHTS
+    let [client_stdin_fd, client_stdout_fd, client_stderr_fd] =
+        recv_fds_over_unix_socket(&conn, 3)?;
+
+    match request {
+        DaemonRequest::Execute(mut exec_command) => {
+            exec_command.user = Some(user.name);
+            exec_command.group = Some(group.name);
+
+            // Take ownership of the NetworkNamespace object (`_ns`).
+            // It will now be dropped only when `handle_client` finishes,
+            // which happens after the child process has exited.
+            // If the client stdin is a TTY, run the child on a dedicated PTY and bridge I/O.
+            // This preserves job control and avoids stealing the user's controlling TTY.
+            let client_has_tty =
+                nix_isatty(unsafe { BorrowedFd::borrow_raw(client_stdin_fd) }).unwrap_or(false);
+            let (application, ns): (
+                vopono_core::network::application_wrapper::ApplicationWrapper,
+                vopono_core::network::netns::NetworkNamespace,
+            );
+            let mut pty_master: Option<std::os::fd::RawFd> = None;
+            if client_has_tty {
+                let p = openpty(None, None).map_err(|e| anyhow!("openpty failed: {e}"))?;
+                let master = p.master.into_raw_fd();
+                let slave = p.slave.into_raw_fd();
+                // Spawn child with PTY slave as stdio, and let it take controlling TTY in pre_exec
+                (application, ns) = execute_as_daemon_with_stdio(
+                    exec_command,
+                    false,
+                    Some((slave, slave, slave)),
+                    true,
+                )?;
+                // Do not close the slave here: it's owned by the spawned child via Stdio::from_raw_fd
+                // and will be closed by the child/OS when appropriate.
+                pty_master = Some(master);
+            } else {
+                (application, ns) = execute_as_daemon_with_stdio(
+                    exec_command,
+                    false,
+                    Some((client_stdin_fd, client_stdout_fd, client_stderr_fd)),
+                    false,
+                )?;
+            }
+
+            // Keep port-forwarding alive for the lifetime of this handler
+            let port_forward_keepalive = application.port_forwarding;
+            // Inform the client about the forwarded port too (not only daemon logs)
+            if let Some(ref fwd) = port_forward_keepalive
+                && let Ok(dup_fd) =
+                    nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(client_stdout_fd) })
+            {
+                let mut out = std::fs::File::from(dup_fd);
+                let _ = writeln!(out, "Port Forwarding on port {}", fwd.forwarded_port());
+                let _ = out.flush();
+            }
+
+            let mut child = application.handle;
+
+            // Keep the namespace alive while the child runs
+            let _ns_guard = ns;
+
+            // Create a per-client lock file under ~/.config/vopono/locks/<ns>/client-<pid>
+            // so dropping this handler does not delete the namespace if other clients are active.
+            let client_lock_path: Option<PathBuf> = (|| -> anyhow::Result<PathBuf> {
+                let mut lock_dir = vopono_core::util::config_dir()?;
+                lock_dir.push(format!("vopono/locks/{}", _ns_guard.name));
+                std::fs::create_dir_all(&lock_dir)?;
+                let path = lock_dir.join(format!("client-{}", child.id()));
+                std::fs::File::create(&path)?;
+                Ok(path)
+            })()
+            .ok();
+
+            // If using PTY, bridge between client FDs and PTY master
+            let mut exit_status: Option<std::process::ExitStatus> = None;
+            if let Some(master_fd) = pty_master {
+                use std::io::{Read as _, Write as _};
+                // Duplicate client FDs so we don't close the originals when Files drop
+                let client_stdin_dup: OwnedFd =
+                    nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(client_stdin_fd) })?;
+                let client_stdout_dup: OwnedFd =
+                    nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(client_stdout_fd) })?;
+                let client_stdin = std::fs::File::from(client_stdin_dup);
+                let client_stdout = std::fs::File::from(client_stdout_dup);
+                // We own master_fd; wrap in OwnedFd then File
+                let master_owned = unsafe { OwnedFd::from_raw_fd(master_fd) };
+                let pty_master_file_r = std::fs::File::from(master_owned);
+                let pty_master_file_w = pty_master_file_r.try_clone()?;
+
+                // Do not change user terminal modes; inject control bytes into PTY on signals
+
+                // Control listener: on SIGINT/SIGTSTP/SIGQUIT inject termios cc into PTY master; others killpg
+                let mut ctrl_conn = conn.try_clone()?;
+                let mut pty_writer_for_ctrl = pty_master_file_w.try_clone()?;
+                let child_pgid = nix::unistd::Pid::from_raw(-(child.id() as i32));
+                thread::spawn(move || {
+                    loop {
+                        let mut len_bytes = [0u8; 4];
+                        if ctrl_conn.read_exact(&mut len_bytes).is_err() {
+                            break;
+                        }
+                        let len = u32::from_be_bytes(len_bytes) as usize;
+                        let mut buf = vec![0u8; len];
+                        if ctrl_conn.read_exact(&mut buf).is_err() {
+                            break;
+                        }
+                        if let Ok((DaemonRequest::Control(ctrl), _)) =
+                            bincode::serde::decode_from_slice::<DaemonRequest, _>(
+                                &buf,
+                                bincode::config::standard(),
+                            )
+                        {
+                            match ctrl {
+                                DaemonControl::Signal(sig) => {
+                                    if let Ok(sig_enum) = nix::sys::signal::Signal::try_from(sig) {
+                                        match sig_enum {
+                                            nix::sys::signal::Signal::SIGINT => {
+                                                let _ = pty_writer_for_ctrl.write_all(&[0x03]);
+                                                let _ = pty_writer_for_ctrl.flush();
+                                            }
+                                            nix::sys::signal::Signal::SIGTSTP => {
+                                                let _ = pty_writer_for_ctrl.write_all(&[0x1A]);
+                                                let _ = pty_writer_for_ctrl.flush();
+                                            }
+                                            nix::sys::signal::Signal::SIGQUIT => {
+                                                let _ = pty_writer_for_ctrl.write_all(&[0x1C]);
+                                                let _ = pty_writer_for_ctrl.flush();
+                                            }
+                                            _ => {
+                                                let _ =
+                                                    nix::sys::signal::kill(child_pgid, sig_enum);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+
+                let (tx_done, _rx_done) = mpsc::channel::<()>();
+                // stdin copier: client stdin -> pty master
+                let tx_done_stdin = tx_done.clone();
+                let mut stdin_reader = client_stdin;
+                let mut pty_writer = pty_master_file_w;
+                let child_pgid_for_stdin = child_pgid; // Pid is Copy; used for optional SIGHUP on EOF
+                thread::spawn(move || {
+                    let mut buf = [0u8; 4096];
+                    while let Ok(n) = stdin_reader.read(&mut buf) {
+                        if n == 0 {
+                            // Client reached EOF (Ctrl-D in cooked mode or client closed input).
+                            // Inject EOT into the child's TTY so interactive shells exit cleanly.
+                            let _ = pty_writer.write_all(&[0x04]); // EOT
+                            let _ = pty_writer.flush();
+                            // Optional: also send SIGHUP to the child's process group
+                            let _ = nix::sys::signal::kill(
+                                child_pgid_for_stdin,
+                                nix::sys::signal::Signal::SIGHUP,
+                            );
+                            break;
+                        }
+                        if pty_writer.write_all(&buf[..n]).is_err() {
+                            break;
+                        }
+                    }
+                    let _ = tx_done_stdin.send(());
+                });
+
+                // output copier: pty master -> client stdout (stderr merges on TTY)
+                let tx_done_out = tx_done.clone();
+                let mut pty_reader = pty_master_file_r;
+                let mut stdout_writer = client_stdout;
+                thread::spawn(move || {
+                    let mut buf = [0u8; 4096];
+                    while let Ok(n) = pty_reader.read(&mut buf) {
+                        if n == 0 {
+                            break;
+                        }
+                        if stdout_writer.write_all(&buf[..n]).is_err() {
+                            break;
+                        }
+                        let _ = stdout_writer.flush();
+                    }
+                    let _ = tx_done_out.send(());
+                });
+
+                // Wait for child to exit; do not block on copier threads
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            exit_status = Some(status);
+                            break;
+                        }
+                        Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
+                        Err(e) => {
+                            log::debug!("try_wait error: {e}");
+                            break;
+                        }
+                    }
+                }
+                // Close fds so copier threads unwind promptly
+                // Copiers own their fds; nothing more to drop here
+            }
+
+            let status = match exit_status {
+                Some(s) => s,
+                None => child.wait()?,
+            };
+            #[derive(Serialize)]
+            enum FinalResponse {
+                ExitCode(i32),
+            }
+            // Remove per-client lock now that this client has finished
+            if let Some(path) = client_lock_path {
+                let _ = std::fs::remove_file(path);
+            }
+
+            // Ensure port forwarder is dropped before namespace teardown
+            drop(port_forward_keepalive);
+
+            let response = FinalResponse::ExitCode(status.code().unwrap_or(1));
+            let bytes = bincode::serde::encode_to_vec(&response, bincode::config::standard())?;
+            conn.write_all(&(bytes.len() as u32).to_be_bytes())?;
+            conn.write_all(&bytes)?;
+        }
+        DaemonRequest::Control(_) => {
+            // Ignore unexpected control frame sent as the first message
+        }
+    }
+    Ok(())
+}
+
+fn recv_fds_over_unix_socket(
+    conn: &LocalSocketStream,
+    expected: usize,
+) -> anyhow::Result<[RawFd; 3]> {
+    let LocalSocketStream::UdSocket(sock) = conn;
+    let fd = sock.as_fd();
+
+    let mut buf = [0u8; 1];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsg_space = cmsg_space!([RawFd; 3]);
+    let msg = recvmsg::<()>(
+        fd.as_raw_fd(),
+        &mut iov,
+        Some(&mut cmsg_space),
+        MsgFlags::empty(),
+    )?;
+
+    let mut fds: Vec<RawFd> = Vec::new();
+    if let Ok(iter) = msg.cmsgs() {
+        for c in iter {
+            if let ControlMessageOwned::ScmRights(fdlist) = c {
+                for &f in fdlist.iter() {
+                    fds.push(f);
+                }
+            }
+        }
+    }
+    if fds.len() != expected {
+        return Err(anyhow!(
+            "Did not receive expected number of FDs: got {} expected {}",
+            fds.len(),
+            expected
+        ));
+    }
+    Ok([fds[0], fds[1], fds[2]])
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,25 +5,38 @@
 mod args;
 mod args_config;
 mod cli_client;
+mod daemon;
 mod exec;
 mod list;
 mod list_configs;
 mod sync;
 
+use crate::args::ExecCommand;
+use anyhow::anyhow;
 use clap::Parser;
 use cli_client::CliClient;
+use interprocess::TryClone;
+use interprocess::local_socket::ToFsName;
+use interprocess::local_socket::prelude::*;
+use interprocess::os::unix::local_socket::FilesystemUdSocket;
 use list::output_list;
 use list_configs::print_configs;
-use log::{LevelFilter, warn};
+use log::{LevelFilter, debug, info, warn};
+use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+use signal_hook::consts::{SIGINT, SIGQUIT, SIGTERM, SIGTSTP};
+use signal_hook::iterator::Signals;
+use std::io::IoSlice;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, AsRawFd, RawFd};
 use sync::{sync_menu, synch};
 use vopono_core::util::clean_dead_locks;
 use vopono_core::util::clean_dead_namespaces;
 use vopono_core::util::elevate_privileges;
 
+pub const SOCKET_PATH: &str = "/run/vopono.sock";
+
 fn main() -> anyhow::Result<()> {
-    // Get struct of args using structopt
     let app = args::App::parse();
-    // Set up logging
     let mut builder = pretty_env_logger::formatted_timed_builder();
     builder.parse_default_env();
     if app.verbose {
@@ -38,8 +51,34 @@ fn main() -> anyhow::Result<()> {
     builder.init();
 
     let uiclient = CliClient {};
-    match app.cmd {
+    let cmd = app
+        .cmd
+        .expect("Subcommand is required when not in daemon mode.");
+
+    match cmd {
+        args::Command::Daemon => {
+            if !nix::unistd::getuid().is_root() {
+                eprintln!("Error: The daemon command requires root privileges.");
+                std::process::exit(1);
+            }
+            info!("Starting vopono in daemon mode.");
+            return daemon::start();
+        }
         args::Command::Exec(cmd) => {
+            // If we're not root, try to forward the command to the running daemon.
+            if !nix::unistd::getuid().is_root() {
+                match forward_to_daemon(&cmd) {
+                    Ok(exit_code) => {
+                        std::process::exit(exit_code);
+                    }
+                    Err(e) => {
+                        info!("Falling back to sudo (daemon forward failed): {e}");
+                    }
+                }
+            }
+
+            // If we are root, or if the daemon isn't running, execute directly.
+            info!("Executing with sudo escalation path.");
             clean_dead_locks()?;
             let verbose = app.verbose && !app.silent;
             elevate_privileges(app.askpass)?;
@@ -52,7 +91,6 @@ fn main() -> anyhow::Result<()> {
             output_list(listcmd)?;
         }
         args::Command::Synch(synchcmd) => {
-            // If provider given then sync that, else prompt with menu
             if synchcmd.vpn_provider.is_none() {
                 sync_menu(&uiclient, synchcmd.protocol.map(|x| x.to_variant()))?;
             } else {
@@ -68,4 +106,71 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+fn forward_to_daemon(cmd: &ExecCommand) -> anyhow::Result<i32> {
+    let name = SOCKET_PATH.to_fs_name::<FilesystemUdSocket>()?;
+    let mut conn = match LocalSocketStream::connect(name) {
+        Ok(c) => c,
+        Err(_) => return Err(anyhow!("Daemon not running")),
+    };
+
+    debug!("Connected to daemon, forwarding command.");
+    let request = daemon::DaemonRequest::Execute(cmd.clone());
+    let bytes = bincode::serde::encode_to_vec(&request, bincode::config::standard())?;
+    conn.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    conn.write_all(&bytes)?;
+
+    // Send our stdio FDs to the daemon using SCM_RIGHTS
+    let fds = [
+        std::io::stdin().as_raw_fd(),
+        std::io::stdout().as_raw_fd(),
+        std::io::stderr().as_raw_fd(),
+    ];
+    send_fds_over_unix_socket(&conn, &fds)?;
+
+    // Keep the user's TTY in cooked mode; rely on daemon PTY + signal forwarding.
+
+    // Spawn a signal forwarder thread to deliver user signals to the daemon/child
+    let mut sigs = Signals::new([SIGINT, SIGQUIT, SIGTERM, SIGTSTP])?;
+    let mut conn_ctrl = conn.try_clone()?;
+    std::thread::spawn(move || {
+        for sig in &mut sigs {
+            let ctrl = daemon::DaemonControl::Signal(sig);
+            let req = daemon::DaemonRequest::Control(ctrl);
+            if let Ok(bytes) = bincode::serde::encode_to_vec(&req, bincode::config::standard()) {
+                let _ = conn_ctrl.write_all(&(bytes.len() as u32).to_be_bytes());
+                let _ = conn_ctrl.write_all(&bytes);
+            }
+        }
+    });
+
+    // Read a single final response (length-prefixed) containing the exit code
+    let mut len_bytes = [0u8; 4];
+    conn.read_exact(&mut len_bytes)?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    let mut buffer = vec![0; len];
+    conn.read_exact(&mut buffer)?;
+
+    #[derive(serde::Deserialize)]
+    enum FinalResponse {
+        ExitCode(i32),
+    }
+    let (response, _): (FinalResponse, usize) =
+        bincode::serde::decode_from_slice(&buffer, bincode::config::standard())?;
+    match response {
+        FinalResponse::ExitCode(code) => Ok(code),
+    }
+}
+
+fn send_fds_over_unix_socket(conn: &LocalSocketStream, fds: &[RawFd]) -> anyhow::Result<()> {
+    let LocalSocketStream::UdSocket(sock) = conn;
+    let fd = sock.as_fd();
+    // send a single dummy byte alongside the FD rights
+    let buf = [0u8; 1];
+    let iov = [IoSlice::new(&buf)];
+    let cmsg = ControlMessage::ScmRights(fds);
+    sendmsg::<()>(fd.as_raw_fd(), &iov, &[cmsg], MsgFlags::empty(), None)
+        .map(|_| ())
+        .map_err(|e| e.into())
 }

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -16,7 +16,14 @@ directories-next = "2"
 log = "0.4"
 which = "8"
 users = "0.11"
-nix = { version = "0.30", features = ["user", "signal", "fs", "process"] }
+nix = { version = "0.30", features = [
+    "user",
+    "signal",
+    "fs",
+    "process",
+    "sched",
+    "mount",
+] }
 serde = { version = "1", features = ["derive", "std"] }
 csv = "1"
 regex = "1"
@@ -39,7 +46,7 @@ base64 = "0.22"
 x25519-dalek = { version = "3.0.0-pre.0", features = ["static_secrets"] }
 strum = "0.27"
 strum_macros = "0.27"
-zip = "4"
+zip = "5"
 maplit = "1"
 webbrowser = "1"
 serde_json = "1"

--- a/vopono_core/src/network/application_wrapper.rs
+++ b/vopono_core/src/network/application_wrapper.rs
@@ -1,15 +1,26 @@
 use std::{
+    ffi::CString,
+    os::fd::{BorrowedFd, FromRawFd, IntoRawFd},
+    os::unix::{io::RawFd, process::CommandExt},
     path::PathBuf,
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
 };
 
+use anyhow::Context;
 use log::debug;
+use nix::{
+    fcntl::{OFlag, open},
+    mount::{MsFlags, mount},
+    sched::{CloneFlags, setns, unshare},
+    sys::stat::Mode,
+    unistd::close,
+};
 
 use super::{netns::NetworkNamespace, port_forwarding::Forwarder};
 use crate::util::{env_vars::set_env_vars, get_all_running_process_names, parse_command_str};
 
 pub struct ApplicationWrapper {
-    pub handle: std::process::Child,
+    pub handle: Child,
     pub port_forwarding: Option<Box<dyn Forwarder>>,
 }
 
@@ -24,6 +35,9 @@ impl ApplicationWrapper {
         port_forwarding: Option<Box<dyn Forwarder>>,
         silent: bool,
         host_env_vars: &std::collections::HashMap<String, String>,
+        pipe_io: bool,
+        stdio_fds: Option<(RawFd, RawFd, RawFd)>,
+        take_controlling_tty: bool,
     ) -> anyhow::Result<Self> {
         let running_processes = get_all_running_process_names();
         let app_vec = parse_command_str(application)?;
@@ -38,7 +52,6 @@ impl ApplicationWrapper {
         ]
         .iter()
         {
-            // TODO: Avoid String allocation here
             if app_vec.contains(&shared_process_app.to_string())
                 && running_processes.contains(&shared_process_app.to_string())
             {
@@ -56,8 +69,10 @@ impl ApplicationWrapper {
             user,
             group,
             silent,
-            false,
-            false,
+            pipe_io,
+            pipe_io,
+            stdio_fds,
+            take_controlling_tty,
             working_directory,
             port_forwarding.as_deref(),
             host_env_vars,
@@ -82,55 +97,259 @@ impl ApplicationWrapper {
         silent: bool,
         capture_output: bool,
         capture_input: bool,
+        stdio_fds: Option<(RawFd, RawFd, RawFd)>,
+        take_controlling_tty: bool,
         set_dir: Option<PathBuf>,
         forwarder: Option<&dyn Forwarder>,
         host_env_vars: &std::collections::HashMap<String, String>,
-    ) -> anyhow::Result<std::process::Child> {
-        let mut handle = Command::new("ip");
-        set_env_vars(netns, forwarder, &mut handle, host_env_vars);
-        handle.args(["netns", "exec", netns.name.as_str()]);
-        if let Some(cdir) = set_dir {
-            handle.current_dir(cdir);
-        }
+    ) -> anyhow::Result<Child> {
+        let is_root = nix::unistd::getuid().is_root();
+        let (prog, args) = command.split_first().context("Command cannot be empty")?;
+        let mut handle: Command;
 
-        let mut sudo_args = Vec::new();
-        if let Some(ref user) = user {
-            sudo_args.push("--user");
-            sudo_args.push(user);
-        }
-        if let Some(ref group) = group {
-            sudo_args.push("--group");
-            sudo_args.push(group);
-        }
+        // Use direct setns only for the daemon path. If stdio_fds provided, we must use setns.
+        // Otherwise, fall back to ip netns exec (even when root) for non-daemon usage.
+        let use_direct_setns =
+            is_root && (stdio_fds.is_some() || (capture_output && capture_input));
 
-        let sudo_string = if !sudo_args.is_empty() {
-            let mut args = vec!["sudo", "--preserve-env"];
-            args.append(&mut sudo_args);
-            handle.args(args.clone());
-            Some(format!(" {}", args.join(" ")))
+        if use_direct_setns {
+            handle = Command::new(prog);
+            handle.args(args);
+            // Prepare all data outside the closure
+            let user_details = if let Some(user_name) = user {
+                debug!(
+                    "(daemon) Preparing to run '{}' in netns '{}' as user '{}'",
+                    command.join(" "),
+                    netns.name,
+                    user_name
+                );
+                let target_user = nix::unistd::User::from_name(&user_name)?
+                    .with_context(|| format!("User '{}' not found", user_name))?;
+
+                let target_group = if let Some(group_name) = group {
+                    nix::unistd::Group::from_name(&group_name)?
+                        .with_context(|| format!("Group '{}' not found", group_name))?
+                } else {
+                    nix::unistd::Group::from_gid(target_user.gid)?
+                        .with_context(|| "Primary group for user not found")?
+                };
+
+                //  Before forking, set the DBUS session address environment variable.
+                let dbus_socket_path = format!("/run/user/{}/bus", target_user.uid.as_raw());
+                if std::path::Path::new(&dbus_socket_path).exists() {
+                    let dbus_address = format!("unix:path={}", dbus_socket_path);
+                    debug!("Setting DBUS_SESSION_BUS_ADDRESS to {}", dbus_address);
+                    handle.env("DBUS_SESSION_BUS_ADDRESS", dbus_address);
+                } else {
+                    log::warn!(
+                        "Could not find user DBus socket at {}. Graphical applications may fail to integrate with the desktop.",
+                        dbus_socket_path
+                    );
+                }
+
+                //  Set environment and working directory on the Command builder itself.
+                // This is the safe and correct way to prepare the child's environment.
+                handle.env("HOME", &target_user.dir);
+                handle.env("USER", &target_user.name);
+                handle.env("LOGNAME", &target_user.name);
+
+                if let Some(dir) = set_dir {
+                    handle.current_dir(dir);
+                } else {
+                    handle.current_dir(&target_user.dir);
+                }
+
+                Some((
+                    target_user.uid,
+                    target_group.gid,
+                    CString::new(target_user.name)?,
+                ))
+            } else {
+                if let Some(dir) = set_dir {
+                    handle.current_dir(dir);
+                }
+                None
+            };
+
+            let netns_path_cstr = CString::new(format!("/var/run/netns/{}", netns.name))?;
+            let want_controlling_tty = take_controlling_tty;
+            // Prepare bind-mount sources for /etc overlay
+            let etc_ns_dir = format!("/etc/netns/{}", netns.name);
+            let resolv_src = CString::new(format!("{}/resolv.conf", &etc_ns_dir)).ok();
+            let hosts_src = CString::new(format!("{}/hosts", &etc_ns_dir)).ok();
+            let nsswitch_src = CString::new(format!("{}/nsswitch.conf", &etc_ns_dir)).ok();
+            let resolv_dst = CString::new("/etc/resolv.conf").unwrap();
+            let hosts_dst = CString::new("/etc/hosts").unwrap();
+            let nsswitch_dst = CString::new("/etc/nsswitch.conf").unwrap();
+
+            unsafe {
+                handle.pre_exec(move || {
+                    // The closure now ONLY contains async-signal-safe syscall wrappers.
+                    let ns_fd = open(netns_path_cstr.as_c_str(), OFlag::O_RDONLY, Mode::empty())?;
+                    setns(
+                        ns_fd.try_clone().expect("Clone failed"),
+                        CloneFlags::CLONE_NEWNET,
+                    )
+                    .map_err(|e| std::io::Error::other(format!("pre_exec: setns failed: {e}")))?;
+                    close(ns_fd)?;
+
+                    // Create a private mount namespace for the child to safely overlay /etc files
+                    unshare(CloneFlags::CLONE_NEWNS).map_err(|e| {
+                        std::io::Error::other(format!("pre_exec: unshare(CLONE_NEWNS) failed: {e}"))
+                    })?;
+                    // Make mounts private to avoid propagating to the host
+                    let root_c = CString::new("/").unwrap();
+                    mount::<std::ffi::CStr, std::ffi::CStr, std::ffi::CStr, std::ffi::CStr>(
+                        None,
+                        root_c.as_c_str(),
+                        None,
+                        MsFlags::MS_REC | MsFlags::MS_PRIVATE,
+                        None,
+                    )
+                    .map_err(|e| {
+                        std::io::Error::other(format!("pre_exec: mount MS_PRIVATE failed: {e}"))
+                    })?;
+
+                    // Helper to bind a file if the source exists
+                    let bind_if_exists =
+                        |src_opt: &Option<CString>, dst: &CString| -> Result<(), std::io::Error> {
+                            if let Some(src) = src_opt
+                                && libc::access(src.as_ptr(), libc::R_OK) == 0
+                            {
+                                mount::<
+                                    std::ffi::CStr,
+                                    std::ffi::CStr,
+                                    std::ffi::CStr,
+                                    std::ffi::CStr,
+                                >(
+                                    Some(src.as_c_str()),
+                                    dst.as_c_str(),
+                                    None,
+                                    MsFlags::MS_BIND,
+                                    None,
+                                )
+                                .map_err(|e| {
+                                    std::io::Error::other(format!(
+                                        "pre_exec: bind mount failed: {e}"
+                                    ))
+                                })?;
+                            }
+                            Ok(())
+                        };
+
+                    // Overlay resolv.conf, hosts, nsswitch.conf for proper name resolution within netns
+                    bind_if_exists(&resolv_src, &resolv_dst)?;
+                    bind_if_exists(&hosts_src, &hosts_dst)?;
+                    bind_if_exists(&nsswitch_src, &nsswitch_dst)?;
+
+                    // Enable unprivileged ping inside the netns by widening ping_group_range
+                    // Write "0 2147483647" to /proc/sys/net/ipv4/ping_group_range via raw syscalls
+                    let ping_path = CString::new("/proc/sys/net/ipv4/ping_group_range").unwrap();
+                    let fd = libc::open(ping_path.as_ptr(), libc::O_WRONLY);
+                    if fd >= 0 {
+                        let data = b"0 2147483647\n";
+                        let _ = libc::write(fd, data.as_ptr() as *const _, data.len());
+                        libc::close(fd);
+                    }
+
+                    // If the child should be truly interactive, make it a session leader and
+                    // set the controlling terminal to stdin (fd 0). This fixes bash job control
+                    // and routes signals like Ctrl+C to the child instead of the client.
+                    if want_controlling_tty {
+                        // Create a new session
+                        let _ = libc::setsid();
+                        // If stdin is a TTY, take it as controlling terminal
+                        // Use TIOCSCTTY with arg 1 to forcibly acquire if already in use
+                        let fd0: i32 = 0;
+                        let is_tty = libc::isatty(fd0) == 1;
+                        if is_tty {
+                            let tiocsctty: libc::c_ulong = libc::TIOCSCTTY as _;
+                            let _ = libc::ioctl(fd0, tiocsctty, 1);
+                            // Set foreground process group to our own pgrp
+                            let pgrp = libc::getpgrp();
+                            let _ = libc::tcsetpgrp(fd0, pgrp);
+                        }
+                    }
+
+                    if let Some((uid, gid, user_name_cstr)) = &user_details {
+                        nix::unistd::initgroups(user_name_cstr, *gid)?;
+                        nix::unistd::setgid(*gid)?;
+                        nix::unistd::setuid(*uid)?;
+                    }
+
+                    Ok(())
+                });
+            }
         } else {
-            None
-        };
+            // This non-daemon path remains unchanged
+            handle = Command::new("ip");
+            handle.args(["netns", "exec", netns.name.as_str()]);
+
+            let mut sudo_args: Vec<String> = vec!["sudo".to_string(), "--preserve-env".to_string()];
+            if let Some(user_str) = &user {
+                sudo_args.push("--user".to_string());
+                sudo_args.push(user_str.clone());
+            }
+            if let Some(group_str) = &group {
+                sudo_args.push("--group".to_string());
+                sudo_args.push(group_str.clone());
+            }
+
+            debug!(
+                "ip netns exec {} {} {}",
+                netns.name,
+                sudo_args.join(" "),
+                command.join(" ")
+            );
+            handle.args(sudo_args);
+            handle.args(command);
+            if let Some(cdir) = set_dir {
+                handle.current_dir(cdir);
+            }
+        }
+
+        set_env_vars(netns, forwarder, &mut handle, host_env_vars);
 
         if silent {
             handle.stdout(Stdio::null());
             handle.stderr(Stdio::null());
         }
-        if capture_output {
-            handle.stdout(Stdio::piped());
-            handle.stderr(Stdio::piped());
-        }
-        if capture_input {
-            handle.stdin(Stdio::piped());
+        match (stdio_fds, capture_input, capture_output) {
+            (Some((fd_in, fd_out_orig, fd_err_orig)), _, _) => unsafe {
+                // Ensure each Stdio gets a unique owned fd to avoid double-closing.
+                let in_fd = fd_in;
+                let mut out_fd = fd_out_orig;
+                let mut err_fd = fd_err_orig;
+                if out_fd == in_fd {
+                    out_fd = nix::unistd::dup(BorrowedFd::borrow_raw(out_fd))
+                        .map_err(|e| std::io::Error::other(format!("dup stdout failed: {e}")))?
+                        .into_raw_fd();
+                }
+                if err_fd == in_fd || err_fd == out_fd {
+                    err_fd = nix::unistd::dup(BorrowedFd::borrow_raw(err_fd))
+                        .map_err(|e| std::io::Error::other(format!("dup stderr failed: {e}")))?
+                        .into_raw_fd();
+                }
+                handle.stdin(Stdio::from_raw_fd(in_fd));
+                handle.stdout(Stdio::from_raw_fd(out_fd));
+                handle.stderr(Stdio::from_raw_fd(err_fd));
+            },
+            (None, true, true) => {
+                handle.stdin(Stdio::piped());
+                handle.stdout(Stdio::piped());
+                handle.stderr(Stdio::piped());
+            }
+            (None, true, false) => {
+                handle.stdin(Stdio::piped());
+            }
+            (None, false, true) => {
+                handle.stdout(Stdio::piped());
+                handle.stderr(Stdio::piped());
+            }
+            _ => {}
         }
 
-        debug!(
-            "ip netns exec {}{} {}",
-            netns.name,
-            sudo_string.unwrap_or_else(|| String::from("")),
-            command.join(" ")
-        );
-        let handle = handle.args(command).spawn()?;
-        Ok(handle)
+        let child = handle.spawn()?;
+        Ok(child)
     }
 }


### PR DESCRIPTION
This commit introduces a major new feature: a client-daemon architecture that allows `vopono` to be run by unprivileged users without requiring `sudo` for every command. See issue #298.

Previously, every `vopono exec` invocation required root privileges to manipulate network namespaces, leading to frequent `sudo` password prompts. This was inconvenient for interactive use and a significant barrier for scripting or system integrations (e.g., desktop shortcuts).

This change addresses the problem by splitting `vopono` into two main components:
1.  A persistent, root-level daemon that manages namespaces.
2.  A lightweight client that communicates with the daemon.

## How It Works: The Client-Daemon Flow

1.  **Daemon Startup**: A new `vopono daemon` subcommand is added. This is intended to be run as root, typically via a systemd service. The daemon creates and listens on a Unix domain socket at `/run/vopono.sock`.

2.  **Client Execution**: When a non-root user runs `vopono exec ...`, the client first attempts to connect to this socket.
    - If the daemon is not running, it gracefully falls back to the original behavior, using `sudo` to elevate privileges.
    - If the daemon is running, the client proceeds with the new IPC-based workflow.

3.  **Inter-Process Communication (IPC)**:
    - The client serializes its `ExecCommand` arguments into a binary format (using `bincode`) and sends it to the daemon.
    - Crucially, it then passes its own `stdin` (0), `stdout` (1), and `stderr` (2) file descriptors to the daemon using the `SCM_RIGHTS` control message over the socket. This is a kernel-level mechanism for securely transferring open file handles between processes.

4.  **Daemon-Side Execution**:
    - The daemon accepts the connection and uses `SO_PEERCRED` to securely verify the connecting user's UID and GID. This is essential for security.
    - It receives the command and the file descriptors.
    - It performs all the required privileged operations: creating the network namespace, setting up veth pairs, configuring routing and firewall rules, and running the VPN protocol.

5.  **Spawning the Child Process**:
    - The daemon spawns the user's requested application using a `pre_exec` hook, which allows for fine-grained control before the new program starts.
    - Inside `pre_exec`, it uses `setns()` to move the child into the correct network namespace and `unshare(CLONE_NEWNS)` to give it a private mount namespace. This allows for safely bind-mounting files like `/etc/resolv.conf` without affecting the host.
    - It then drops privileges by setting the child's UID and GID to match those of the original client user.
    - Finally, it connects the child's `stdin`, `stdout`, and `stderr` to the file descriptors it received from the client.

This design ensures that I/O flows directly between the sandboxed application and the user's terminal, with the daemon acting only as a privileged setup coordinator.

## Handling Interactive Sessions and Signals

A significant challenge is correctly handling interactive applications (like shells or text editors) that require a controlling terminal (TTY).

-   **PTY (Pseudoterminal) Creation**: If the daemon detects that the
    client's `stdin` is a TTY, it creates a PTY pair. The child process's
    stdio is connected to the PTY slave, making the application believe it's
    running in a real terminal.

-   **I/O and Signal Forwarding**: The daemon bridges I/O between the client's
    real terminal FDs and the PTY master. When the client traps a signal
    (e.g., `SIGINT` from `Ctrl+C`), it sends a message to the daemon, which
    then injects the corresponding control character into the PTY. This
    ensures that signals are delivered correctly to the application inside
    the namespace, preserving job control and interactive behavior.

When the child process exits, the daemon sends the final exit code back to the client, which then exits with the same code, seamlessly restoring control to the user's original shell.