### PR TITLE
daemon: forward GUI envs; use user XDG config;

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.10.15"
+version = "0.10.16"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2024"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For a smoother experience, run the privileged root daemon and keep using `vopono
 - Or run manually as root: `sudo vopono daemon`
 - Then use vopono normally as your user: `vopono exec --provider mullvad --server se firefox`
 
-See USERGUIDE.md for a ready‑to‑copy systemd unit.
+See [USERGUIDE.md](USERGUIDE.md) for a ready‑to‑copy systemd unit.
 
 vopono can handle up to 255 separate network namespaces (i.e. different VPN server
 connections - if your VPN provider allows it). Commands launched with

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -31,7 +31,7 @@ vopono now supports a persistent root daemon that handles all privileged work. R
 
 Signals (e.g., Ctrl+C, Ctrl+Z) and interactive TTY behavior work cleanly via the daemon. The daemon listens on `/run/vopono.sock` and cleans it up on exit.
 
-Example systemd unit for the root daemon (`/etc/systemd/system/vopono-daemon.service`):
+Example systemd unit for the root daemon (`/etc/systemd/system/vopono.service`):
 
 ```
 [Unit]
@@ -54,8 +54,8 @@ WantedBy=multi-user.target
 Check status and logs:
 
 ```
-sudo systemctl status vopono-daemon
-sudo journalctl -u vopono-daemon -e
+sudo systemctl status vopono
+sudo journalctl -u vopono -e
 ```
 
 Note there is a known issue that when using tmux, etc. - sometimes the

--- a/vopono.service
+++ b/vopono.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Vopono root daemon
+After=network.target
+Requires=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/vopono daemon
+Restart=on-failure
+RestartSec=2s
+# Optional: enable structured logs
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono_core"
 description = "Library code for running VPN connections in network namespaces"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
  - Forward essential X/Wayland env vars from client to daemon-launched apps: DISPLAY, WAYLAND_DISPLAY, XAUTHORITY, XDG_RUNTIME_DIR, XDG_CONFIG_HOME, XDG_SESSION_TYPE, MOZ_ENABLE_WAYLAND, QT_QPA_PLATFORM, GTK_MODULES, GTK3_MODULES, I3SOCK. Default XDG_RUNTIME_DIR to /run/user/<uid> when missing.
  - Extend DaemonRequest to carry the forwarded env map; merge into child env in daemon path.
  - Respect XDG_CONFIG_HOME in daemon mode: add thread-local config_dir override and set it per client to forwarded XDG_CONFIG_HOME (if it exists) or fall back to ~/.config of the connecting user. Clear the override when the handler exits. This fixes false “config files … do not exist” when the daemon runs under systemd.
  - Demote noisy “Could not get PULSE_SERVER from host” to debug in daemon mode (still warn in non-daemon). Daemon continues to set PULSE_SERVER to unix:/run/user/<uid>/pulse/native for the connecting user.
  - Add daemon mode flag in core (set_daemon_mode/is_daemon_mode); mark daemon context in main and use it for conditional logging.
  - Avoid interactive auto-sync in daemon mode: setup_namespace now accepts auto_sync_if_missing; daemon passes false (bails with a clear message if configs are missing), CLI path passes true (preserving previous behavior).
  - Pass env and stdio consistently for both TTY and non-TTY client cases.

  Result:

  - GUI apps launched via the daemon get correct X/Wayland/desktop env and no longer fail with “no DISPLAY”.
  - Daemon resolves configs from the user’s XDG config dir instead of /root/.config under systemd.
  - Systemd logs are quieter; no spurious PULSE warnings or “not a terminal” from attempted interactive sync.