### PR TITLE
Fix bug when using sync when daemon is running

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -150,6 +150,7 @@ fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
                 })
                 .unwrap_or_else(|| user.dir.join(".config"));
             vopono_core::util::set_config_dir_override(Some(override_base));
+            vopono_core::util::set_config_owner_override(Some((uid, gid)));
             exec_command.user = Some(user.name);
             exec_command.group = Some(group.name);
 
@@ -377,6 +378,7 @@ fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
     }
     // Clear any thread-local override before exiting the handler
     vopono_core::util::set_config_dir_override(None);
+    vopono_core::util::set_config_owner_override(None);
     Ok(())
 }
 

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -46,7 +46,7 @@ base64 = "0.22"
 x25519-dalek = { version = "3.0.0-pre.0", features = ["static_secrets"] }
 strum = "0.27"
 strum_macros = "0.27"
-zip = "5"
+zip = "6"
 maplit = "1"
 webbrowser = "1"
 serde_json = "1"


### PR DESCRIPTION
Fix bug when using sync when daemon is running, that could result in ~/.config/vopono being owned by root