### PR TITLE
Add extra logging for chown

### DIFF
--- a/vopono_core/src/util/mod.rs
+++ b/vopono_core/src/util/mod.rs
@@ -197,6 +197,13 @@ pub fn set_config_permissions() -> anyhow::Result<()> {
         |(uid, gid)| Ok((Some(uid), Some(gid))),
     )?;
 
+    debug!(
+        "Setting config permissions in {} to user: {:?}, group: {:?}",
+        check_dir.display(),
+        user,
+        group
+    );
+
     let file_permissions = Permissions::from_mode(0o640);
     let dir_permissions = Permissions::from_mode(0o750);
 


### PR DESCRIPTION
Issue was fixed in #337 but this helps to notice it e.g. when the daemon was still running an older version.