### PR TITLE
Fix VPN return traffic drops on strict rp_filter hosts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono"
 description = "Launch applications via VPN tunnels using temporary network namespaces"
-version = "0.10.21"
+version = "0.10.22"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 edition = "2024"
 license = "GPL-3.0-or-later"

--- a/vopono_core/Cargo.toml
+++ b/vopono_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vopono_core"
 description = "Library code for running VPN connections in network namespaces"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 authors = ["James McMurray <jamesmcm03@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/vopono_core/src/network/firewall.rs
+++ b/vopono_core/src/network/firewall.rs
@@ -1,4 +1,5 @@
 use super::netns::NetworkNamespace;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter};
 
@@ -54,6 +55,73 @@ pub fn disable_ipv6(netns: &NetworkNamespace, firewall: Firewall) -> anyhow::Res
                     &netns.name,
                     "drop_ipv6_forward",
                     "{ type filter hook forward priority -1 ; policy drop; }",
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Tag return traffic entering the namespace through the host veth with the
+/// Wireguard fwmark. These packets are the only tunnel-related traffic that
+/// arrives outside the tunnel device; without the tag their reverse-path
+/// lookup follows the fwmark policy routing table back to the tunnel device
+/// instead of the ingress interface, so hosts enforcing strict reverse-path
+/// filtering (rp_filter=1) silently drop them. Requires
+/// net.ipv4.conf.*.src_valid_mark=1 (set during Wireguard setup) for the
+/// kernel to honour the mark during source validation. Rules live inside the
+/// namespace and are discarded with it.
+pub fn tag_return_traffic(
+    netns: &NetworkNamespace,
+    ingress_iface: &str,
+    fwmark: &str,
+    firewall: Firewall,
+) -> anyhow::Result<()> {
+    debug!(
+        "Tagging return traffic on {ingress_iface} with fwmark {fwmark} in netns {}",
+        netns.name
+    );
+    match firewall {
+        Firewall::IpTables => NetworkNamespace::exec(
+            &netns.name,
+            &[
+                "iptables",
+                "-t",
+                "mangle",
+                "-A",
+                "PREROUTING",
+                "-i",
+                ingress_iface,
+                "-j",
+                "MARK",
+                "--set-xmark",
+                fwmark,
+            ],
+        )?,
+        Firewall::NfTables => {
+            NetworkNamespace::exec(&netns.name, &["nft", "add", "table", "ip", &netns.name])?;
+            NetworkNamespace::exec(
+                &netns.name,
+                &[
+                    "nft",
+                    "add",
+                    "chain",
+                    "ip",
+                    &netns.name,
+                    "prerouting_mark",
+                    "{ type filter hook prerouting priority -150 ; }",
+                ],
+            )?;
+            NetworkNamespace::exec(
+                &netns.name,
+                &[
+                    "nft",
+                    "add",
+                    "rule",
+                    "ip",
+                    &netns.name,
+                    "prerouting_mark",
+                    &format!("iifname \"{ingress_iface}\" meta mark set {fwmark}"),
                 ],
             )?;
         }

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -7,6 +7,7 @@ use super::openfortivpn::OpenFortiVpn;
 use super::openvpn::OpenVpn;
 use super::shadowsocks::Shadowsocks;
 use super::ssh::SshProxy;
+use super::sysctl::SysCtl;
 use super::trojan::TrojanHost;
 use super::trojan::trojan_exec::Trojan;
 use super::veth_pair::VethPair;
@@ -512,6 +513,10 @@ impl NetworkNamespace {
                 .context("Failed to add IPv6 host access route")?;
             }
         }
+
+        // Strict reverse-path filtering on the host would silently drop VPN
+        // return traffic entering via the veth, so relax it in the namespace.
+        SysCtl::relax_strict_rp_filter(&self.name)?;
 
         // Store the IPs
         self.veth_pair_ips = Some(veth_ips);

--- a/vopono_core/src/network/sysctl.rs
+++ b/vopono_core/src/network/sysctl.rs
@@ -1,5 +1,7 @@
 use crate::util::sudo_command;
 use anyhow::{Context, anyhow};
+use log::{debug, info};
+use std::process::Command;
 
 pub struct SysCtl {}
 
@@ -19,6 +21,68 @@ impl SysCtl {
 
     pub fn enable_ipv4_forwarding() -> anyhow::Result<Self> {
         Self::enable_forwarding(false)
+    }
+
+    /// VPN return traffic enters the namespace unmarked via the veth interface,
+    /// while tunnel policy routing (e.g. WireGuard's fwmark rules) can direct
+    /// the reverse lookup for the remote endpoint to the tunnel device instead.
+    /// With strict reverse-path filtering (rp_filter=1) such packets are
+    /// silently dropped before reaching the application, which breaks
+    /// connectivity when the host enables strict mode (e.g. via ufw's
+    /// sysctl.conf overriding the distro default of loose mode).
+    /// Loose mode (2) keeps anti-spoofing checks but tolerates this asymmetry,
+    /// so only relax settings that are actually strict.
+    pub fn relax_strict_rp_filter(netns_name: &str) -> anyhow::Result<()> {
+        for key in [
+            "net.ipv4.conf.all.rp_filter",
+            "net.ipv4.conf.default.rp_filter",
+        ] {
+            let value = read_netns_sysctl(netns_name, key)?;
+            match parse_rp_filter_value(&value, key)? {
+                1 => {
+                    info!(
+                        "Strict reverse-path filtering detected ({key}=1) in netns {netns_name}, relaxing to loose mode (2)"
+                    );
+                    sudo_command(&[
+                        "ip",
+                        "netns",
+                        "exec",
+                        netns_name,
+                        "sysctl",
+                        "-q",
+                        &format!("{key}=2"),
+                    ])
+                    .with_context(|| format!("Failed to set {key}=2 in netns: {netns_name}"))?;
+                }
+                value => {
+                    debug!("{key}={value} in netns {netns_name}: no change needed");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn read_netns_sysctl(netns_name: &str, key: &str) -> anyhow::Result<String> {
+    let output = Command::new("ip")
+        .args(["netns", "exec", netns_name, "sysctl", "-n", key])
+        .output()
+        .with_context(|| format!("Failed to read {key} in netns: {netns_name}"))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Failed to read {key} in netns {netns_name}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn parse_rp_filter_value(value: &str, sysctl_name: &str) -> anyhow::Result<u8> {
+    match value.trim() {
+        "0" => Ok(0),
+        "1" => Ok(1),
+        "2" => Ok(2),
+        value => Err(anyhow!("Unexpected value for {sysctl_name}: {value:?}")),
     }
 }
 
@@ -61,5 +125,18 @@ mod tests {
     #[test]
     fn rejects_invalid_forwarding_values() {
         assert!(parse_forwarding_value("enabled", "test.forwarding").is_err());
+    }
+
+    #[test]
+    fn parses_rp_filter_values() {
+        assert_eq!(parse_rp_filter_value("0\n", "test.rp_filter").unwrap(), 0);
+        assert_eq!(parse_rp_filter_value(" 1 ", "test.rp_filter").unwrap(), 1);
+        assert_eq!(parse_rp_filter_value("2", "test.rp_filter").unwrap(), 2);
+    }
+
+    #[test]
+    fn rejects_invalid_rp_filter_values() {
+        assert!(parse_rp_filter_value("strict", "test.rp_filter").is_err());
+        assert!(parse_rp_filter_value("", "test.rp_filter").is_err());
     }
 }

--- a/vopono_core/src/network/wireguard.rs
+++ b/vopono_core/src/network/wireguard.rs
@@ -363,13 +363,7 @@ impl Wireguard {
             &[&executable_wg, "set", &if_name, "fwmark", fwmark],
         )?;
 
-        add_endpoint_bypass_route(
-            namespace,
-            peer_endpoint_ip,
-            &config.peer.allowed_ips,
-            has_ipv4_default,
-            has_ipv6_default,
-        )?;
+        add_endpoint_bypass_route(namespace, peer_endpoint_ip, &config.peer.allowed_ips)?;
         add_routes(
             namespace,
             &if_name,
@@ -386,6 +380,19 @@ impl Wireguard {
                 &["sysctl", "-q", "net.ipv4.conf.all.src_valid_mark=1"],
             )?;
         }
+
+        // Tag veth-ingress return traffic with the tunnel fwmark so its
+        // reverse path stays symmetric even under strict rp_filter.
+        crate::network::firewall::tag_return_traffic(
+            namespace,
+            &namespace
+                .veth_pair
+                .as_ref()
+                .context("Veth pair not set while tagging return traffic")?
+                .source,
+            fwmark,
+            firewall,
+        )?;
 
         if disable_ipv6 {
             crate::network::firewall::disable_ipv6(namespace, firewall)?;
@@ -606,30 +613,25 @@ fn select_endpoint_ip(addresses: &[IpAddr], disable_ipv6: bool) -> anyhow::Resul
         .ok_or_else(|| anyhow!("No Wireguard endpoint addresses were resolved"))
 }
 
-fn endpoint_needs_bypass_route(
-    endpoint: IpAddr,
-    allowed_ips: &[IpNet],
-    has_family_default: bool,
-) -> bool {
-    !has_family_default
-        && allowed_ips
-            .iter()
-            .any(|network| network.contains(&endpoint))
+/// The endpoint is the only remote whose traffic enters/leaves the namespace
+/// via the veth instead of the tunnel, so its route must stay symmetric:
+/// without a specific route in the main table, an unmarked return packet from
+/// the endpoint reverse-routes through the fwmark policy table to the tunnel
+/// device and hosts with strict reverse-path filtering (rp_filter=1) silently
+/// drop it. A /32 (or /128) via the veth gateway keeps both directions on the
+/// veth regardless of rp_filter mode.
+fn endpoint_needs_bypass_route(endpoint: IpAddr, allowed_ips: &[IpNet]) -> bool {
+    allowed_ips
+        .iter()
+        .any(|network| network.contains(&endpoint))
 }
 
 fn add_endpoint_bypass_route(
     namespace: &NetworkNamespace,
     endpoint: IpAddr,
     allowed_ips: &[IpNet],
-    has_ipv4_default: bool,
-    has_ipv6_default: bool,
 ) -> anyhow::Result<()> {
-    let has_family_default = if endpoint.is_ipv4() {
-        has_ipv4_default
-    } else {
-        has_ipv6_default
-    };
-    if !endpoint_needs_bypass_route(endpoint, allowed_ips, has_family_default) {
+    if !endpoint_needs_bypass_route(endpoint, allowed_ips) {
         return Ok(());
     }
 
@@ -1015,23 +1017,26 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_inside_split_tunnel_needs_bypass_route() {
+    fn endpoint_inside_allowed_ips_needs_bypass_route() {
         let allowed_ips = networks(&["192.168.1.0/24"]);
 
         assert!(endpoint_needs_bypass_route(
             "192.168.1.10".parse().unwrap(),
-            &allowed_ips,
-            false
+            &allowed_ips
         ));
         assert!(!endpoint_needs_bypass_route(
             "203.0.113.10".parse().unwrap(),
-            &allowed_ips,
-            false
+            &allowed_ips
         ));
-        assert!(!endpoint_needs_bypass_route(
-            "192.168.1.10".parse().unwrap(),
-            &allowed_ips,
-            true
+
+        let default_allowed_ips = networks(&["0.0.0.0/0", "::/0"]);
+        assert!(endpoint_needs_bypass_route(
+            "203.0.113.10".parse().unwrap(),
+            &default_allowed_ips
+        ));
+        assert!(endpoint_needs_bypass_route(
+            "2001:db8::10".parse().unwrap(),
+            &default_allowed_ips
         ));
     }
 


### PR DESCRIPTION
- Add endpoint bypass route whenever the endpoint falls inside AllowedIPs, not only when no default route is present, keeping the endpoint reverse path symmetric through the veth
- Tag veth-ingress return traffic with the Wireguard fwmark (iptables mangle PREROUTING / nftables prerouting chain) so its reverse-path lookup resolves via the main table instead of the fwmark policy table; relies on src_valid_mark=1 already set during Wireguard setup
- As a fallback for protocols without a fwmark (e.g. OpenVPN), relax rp_filter from strict to loose inside new namespaces only when strict filtering is detected (e.g. ufw's sysctl.conf overriding distro defaults)
- Bump versions: vopono 0.10.22, vopono_core 0.1.22

Specifically this fix is for ufw on Omarchy 4.0