### PR TITLE
Add namespace connectivity check and --existing-netns attach mode

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -124,17 +124,22 @@ file, so you no longer need to repeat them.
 
 ### Checking connectivity
 
-`check` runs a TCP connectivity probe inside a running namespace. It uses the
-root daemon when available (unprivileged users cannot enter namespaces) and
-falls back to sudo otherwise:
+`check` probes a running namespace over both address families (one TCP
+connection each) plus a DNS resolution using the namespace's own resolver.
+It uses the root daemon when available (unprivileged users cannot enter
+namespaces) and falls back to sudo otherwise:
 
 ```bash
 $ vopono check vo_ar_romania
-vo_ar_romania	connected	38ms	tcp 1.1.1.1:443
+vo_ar_romania	connected	v4 69ms	v6 69ms	dns 1.0.0.1,1.1.1.1,2606:4700:4700::1001,2606:4700:4700::1111 55ms
 ```
 
-The target host and port can be overridden with `--host`, `--port` and
-`--timeout-ms`; use `--json` for machine-readable output:
+Each family is reported independently, so a half-broken tunnel is visible at
+a glance (`v4 69ms v6 failed (network unreachable)`). Targets can be
+overridden with `--v4-host`, `--v6-host` and `--port`; individual checks can
+be skipped with `--skip-ipv4`, `--skip-ipv6`, `--skip-dns`; the DNS hostname
+with `--dns-host`; and the per-family timeout with `--timeout-ms`. Use
+`--json` for machine-readable output:
 
 ```bash
 $ vopono check vo_ar_romania --json
@@ -143,11 +148,44 @@ $ vopono check vo_ar_romania --json
   "result": {
     "id": "vo_ar_romania",
     "connected": true,
-    "latency_ms": 38,
-    "target": "tcp 1.1.1.1:443"
+    "ipv4": {
+      "target": "1.1.1.1:443",
+      "latency_ms": 69
+    },
+    "ipv6": {
+      "target": "[2606:4700:4700::1111]:443",
+      "latency_ms": 69
+    },
+    "dns": {
+      "host": "one.one.one.one",
+      "resolved_ips": ["1.0.0.1", "1.1.1.1", "2606:4700:4700::1001", "2606:4700:4700::1111"],
+      "latency_ms": 55
+    }
   }
 }
 ```
+
+When run as an unprivileged user, `check` transparently forwards the probe to
+the running root daemon (falling back to sudo when no daemon is available), so
+frontends can treat namespace health as a daemon capability without spawning
+anything inside the namespace themselves.
+
+### Launch reports and sync stamps
+
+`vopono exec --json` emits a single-line launch summary on stdout once the
+application has started:
+
+```json
+{"version":1,"event":"launched","namespace":"vo_ar_romania","pid":183041,"forwarded_port":null}
+```
+
+Scan stdout for `"event":"launched"` rather than assuming it is the first
+line - host-side setup commands may print earlier lines.
+
+Every completed `vopono sync` also updates `~/.config/vopono/.last-sync`
+with the timestamp, provider and protocol, so frontends can detect newly
+synced configurations by watching that single file instead of polling
+`providers --json`.
 
 Note you can set config files in `/etc/netns/vo_none_None/` to have them
 apply only in the network namespace e.g.:
@@ -250,6 +288,10 @@ the proxy through `vopono.host`. The proxy should listen only on the vopono host
 interface or otherwise be protected from unintended access.
 
 If provider port forwarding is enabled (e.g. `--port-forwarding` or `--custom-port-forwarding` with ProtonVPN or PIA) then the forwarded port is provided as `$VOPONO_FORWARDED_PORT`.
+
+When the provider renews the forwarded port, the new value is picked up
+automatically: forwarders record each renewal and `vopono status --json`
+always reports the current port in the namespace's `port_forwarding` field.
 
 ### Running commands before and after execution within the network namespace
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -94,9 +94,59 @@ execute your internal VPN command. Note the `-i foo` which tells vopono
 to use the Wireguard interface for connecting the network namespace!
 
 ```sh
-$ vopono -v exec --create-netns-only --provider None --protocol None --server None -i foo bash
-$ sudo ip netns exec vo_none_None bash
+$ vopono -v exec --provider None -i foo bash
+$ sudo ip netns exec vo_none_none bash
 $ ./vpn.sh
+```
+
+### Attaching to an existing namespace
+
+Use `--existing-netns` to launch another application in a namespace that is
+already running, without repeating the provider, protocol and server
+arguments:
+
+```bash
+$ vopono exec --existing-netns vo_ar_romania firefox-developer-edition
+```
+
+Nothing else should be passed with `--existing-netns`: connection settings
+are taken from the running namespace, and provider/protocol/server defaults
+in your vopono config.toml are ignored for the launch.
+
+Namespaces created by vopono are reused as-is and keep their normal
+lifecycle. Foreign namespaces (created by hand or other tools) are also
+supported: vopono attaches without modifying them, does not track them in
+`vopono status`, and leaves them running when the application exits.
+
+Similarly, `--provider None` on its own creates a fresh namespace without any
+VPN service - it overrides protocol and server settings from the CLI or config
+file, so you no longer need to repeat them.
+
+### Checking connectivity
+
+`check` runs a TCP connectivity probe inside a running namespace. It uses the
+root daemon when available (unprivileged users cannot enter namespaces) and
+falls back to sudo otherwise:
+
+```bash
+$ vopono check vo_ar_romania
+vo_ar_romania	connected	38ms	tcp 1.1.1.1:443
+```
+
+The target host and port can be overridden with `--host`, `--port` and
+`--timeout-ms`; use `--json` for machine-readable output:
+
+```bash
+$ vopono check vo_ar_romania --json
+{
+  "version": 1,
+  "result": {
+    "id": "vo_ar_romania",
+    "connected": true,
+    "latency_ms": 38,
+    "target": "tcp 1.1.1.1:443"
+  }
+}
 ```
 
 Note you can set config files in `/etc/netns/vo_none_None/` to have them

--- a/src/args.rs
+++ b/src/args.rs
@@ -422,6 +422,11 @@ pub struct ExecCommand {
     /// Port of the remote SSH server
     #[clap(long = "ssh-port")]
     pub ssh_port: Option<u16>,
+
+    /// Emit a machine-readable launch report (namespace, PID, forwarded port)
+    /// as the first line on stdout.
+    #[clap(long = "json")]
+    pub json: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -429,17 +434,37 @@ pub struct CheckCommand {
     /// Network namespace ID (as shown by `vopono status`)
     pub id: String,
 
-    /// Target host to connect to (IP or hostname, resolved inside the namespace)
-    #[clap(long = "host")]
-    pub host: Option<String>,
-
-    /// TCP port to connect to on the target host
+    /// TCP port used for both family checks
     #[clap(long = "port", default_value_t = crate::check::DEFAULT_CHECK_PORT)]
     pub port: u16,
 
-    /// Connection timeout in milliseconds
-    #[clap(long = "timeout-ms", default_value_t = crate::check::DEFAULT_CHECK_TIMEOUT_MS)]
+    /// Connection timeout in milliseconds per family
+    #[clap(long = "timeout-ms", default_value_t = crate::check::DEFAULT_TIMEOUT_MS)]
     pub timeout_ms: u64,
+
+    /// IPv4 target to connect to
+    #[clap(long = "v4-host")]
+    pub v4_host: Option<String>,
+
+    /// IPv6 target to connect to
+    #[clap(long = "v6-host")]
+    pub v6_host: Option<String>,
+
+    /// Skip the IPv4 connectivity check
+    #[clap(long = "skip-ipv4")]
+    pub skip_ipv4: bool,
+
+    /// Skip the IPv6 connectivity check
+    #[clap(long = "skip-ipv6")]
+    pub skip_ipv6: bool,
+
+    /// Hostname resolved via the namespace's own DNS configuration
+    #[clap(long = "dns-host")]
+    pub dns_host: Option<String>,
+
+    /// Skip the DNS resolution check
+    #[clap(long = "skip-dns")]
+    pub skip_dns: bool,
 
     /// Emit versioned JSON instead of human-readable output.
     #[clap(long = "json")]
@@ -447,17 +472,33 @@ pub struct CheckCommand {
 }
 
 /// Hidden helper executed inside a network namespace by the connectivity
-/// check. Performs one TCP connect and exits 0/1.
+/// check. Probes each enabled address family plus optional DNS resolution and
+/// exits 0/1.
 #[derive(Parser, Debug)]
 pub struct ProbeCommand {
-    #[clap(long = "host")]
-    pub host: String,
+    #[clap(long = "v4-host")]
+    pub v4_host: Option<String>,
+
+    #[clap(long = "v6-host")]
+    pub v6_host: Option<String>,
 
     #[clap(long = "port")]
     pub port: u16,
 
     #[clap(long = "timeout-ms")]
     pub timeout_ms: u64,
+
+    #[clap(long = "dns-host")]
+    pub dns_host: Option<String>,
+
+    #[clap(long = "skip-ipv4")]
+    pub skip_ipv4: bool,
+
+    #[clap(long = "skip-ipv6")]
+    pub skip_ipv6: bool,
+
+    #[clap(long = "skip-dns")]
+    pub skip_dns: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -635,9 +676,29 @@ mod tests {
             panic!("expected check command");
         };
         assert_eq!(command.id, "vo_ar_romania");
-        assert_eq!(command.host, None);
+        assert_eq!(command.v4_host, None);
+        assert_eq!(command.v6_host, None);
+        assert!(!command.skip_ipv4);
+        assert!(!command.skip_ipv6);
         assert_eq!(command.port, crate::check::DEFAULT_CHECK_PORT);
-        assert_eq!(command.timeout_ms, crate::check::DEFAULT_CHECK_TIMEOUT_MS);
+        assert_eq!(command.timeout_ms, crate::check::DEFAULT_TIMEOUT_MS);
+        assert_eq!(command.dns_host, None);
+        assert!(!command.skip_dns);
         assert!(command.json);
+    }
+
+    #[test]
+    fn provider_values_parse_case_insensitively() {
+        for spelling in ["airvpn", "AirVPN", "AIRVPN", "aIrVpN"] {
+            let app =
+                App::try_parse_from(["vopono", "exec", "-p", spelling, "-c", "None", "x"]).unwrap();
+            let Command::Exec(command) = app.cmd.unwrap() else {
+                panic!("expected exec command");
+            };
+            assert_eq!(
+                command.provider.unwrap().to_variant(),
+                vopono_core::config::providers::VpnProvider::AirVPN
+            );
+        }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -44,6 +44,10 @@ where
 }
 
 impl<T: IntoEnumIterator + Clone + Display> WrappedArg<T> {
+    pub fn new(variant: T) -> Self {
+        Self { variant }
+    }
+
     pub fn to_variant(&self) -> T {
         self.variant.clone()
     }
@@ -114,6 +118,17 @@ pub enum Command {
         about = "Execute an application with the given VPN connection"
     )]
     Exec(ExecCommand),
+    #[clap(
+        name = "check",
+        about = "Check network connectivity of a running namespace"
+    )]
+    Check(CheckCommand),
+    #[clap(
+        name = "__connectivity-probe",
+        about = "Internal TCP probe executed inside a network namespace",
+        hide = true
+    )]
+    Probe(ProbeCommand),
     #[clap(
         name = "list",
         about = "List running vopono namespaces and applications"
@@ -340,6 +355,17 @@ pub struct ExecCommand {
     #[clap(long = "vopono-config")]
     pub vopono_config: Option<PathBuf>,
 
+    /// Attach to an existing network namespace by name (e.g. vo_ar_romania)
+    /// instead of creating a new connection. Namespaces created by vopono are
+    /// used as-is; foreign namespaces are attached without modifying them and
+    /// are left running on exit. Provider, protocol, server and custom config
+    /// options are ignored.
+    #[clap(
+        long = "existing-netns",
+        conflicts_with_all = &["provider", "protocol", "server", "custom", "custom_netns_name"]
+    )]
+    pub existing_netns: Option<String>,
+
     /// Custom name for the generated network namespace
     /// Will use this network namespace directly if it exists
     #[clap(long = "custom-netns-name")]
@@ -396,6 +422,42 @@ pub struct ExecCommand {
     /// Port of the remote SSH server
     #[clap(long = "ssh-port")]
     pub ssh_port: Option<u16>,
+}
+
+#[derive(Parser, Debug)]
+pub struct CheckCommand {
+    /// Network namespace ID (as shown by `vopono status`)
+    pub id: String,
+
+    /// Target host to connect to (IP or hostname, resolved inside the namespace)
+    #[clap(long = "host")]
+    pub host: Option<String>,
+
+    /// TCP port to connect to on the target host
+    #[clap(long = "port", default_value_t = crate::check::DEFAULT_CHECK_PORT)]
+    pub port: u16,
+
+    /// Connection timeout in milliseconds
+    #[clap(long = "timeout-ms", default_value_t = crate::check::DEFAULT_CHECK_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+
+    /// Emit versioned JSON instead of human-readable output.
+    #[clap(long = "json")]
+    pub json: bool,
+}
+
+/// Hidden helper executed inside a network namespace by the connectivity
+/// check. Performs one TCP connect and exits 0/1.
+#[derive(Parser, Debug)]
+pub struct ProbeCommand {
+    #[clap(long = "host")]
+    pub host: String,
+
+    #[clap(long = "port")]
+    pub port: u16,
+
+    #[clap(long = "timeout-ms")]
+    pub timeout_ms: u64,
 }
 
 #[derive(Parser, Debug)]
@@ -526,6 +588,56 @@ mod tests {
             panic!("expected list command");
         };
         assert!(matches!(command.list_type, Some(ListType::Namespaces)));
+        assert!(command.json);
+    }
+
+    #[test]
+    fn existing_netns_rejects_connection_settings() {
+        for extra in [
+            vec!["--provider", "mullvad"],
+            vec!["--protocol", "wireguard"],
+            vec!["--server", "se"],
+            vec!["--custom", "/tmp/foo.conf"],
+            vec!["--custom-netns-name", "vo_x"],
+        ] {
+            let mut argv = vec!["vopono", "exec", "--existing-netns", "vo_ar_romania"];
+            argv.extend(extra);
+            argv.push("firefox");
+            assert!(
+                App::try_parse_from(argv).is_err(),
+                "expected conflict error"
+            );
+        }
+    }
+
+    #[test]
+    fn existing_netns_parses_standalone() {
+        let app = App::try_parse_from([
+            "vopono",
+            "exec",
+            "--existing-netns",
+            "vo_ar_romania",
+            "firefox",
+        ])
+        .unwrap();
+        let Command::Exec(command) = app.cmd.unwrap() else {
+            panic!("expected exec command");
+        };
+        assert_eq!(command.existing_netns.as_deref(), Some("vo_ar_romania"));
+        assert!(command.provider.is_none());
+        assert!(command.protocol.is_none());
+    }
+
+    #[test]
+    fn check_defaults_and_json() {
+        let app = App::try_parse_from(["vopono", "check", "vo_ar_romania", "--json"]).unwrap();
+        let Command::Check(command) = app.cmd.unwrap() else {
+            panic!("expected check command");
+        };
+        assert_eq!(command.id, "vo_ar_romania");
+        assert_eq!(command.host, None);
+        assert_eq!(command.port, crate::check::DEFAULT_CHECK_PORT);
+        assert_eq!(command.timeout_ms, crate::check::DEFAULT_CHECK_TIMEOUT_MS);
         assert!(command.json);
     }
 }

--- a/src/args_config.rs
+++ b/src/args_config.rs
@@ -271,9 +271,18 @@ impl ArgsConfig {
                 let msg = "VPN server prefix must be provided as a command-line argument or in the vopono config.toml file";
                 log::error!("{msg}"); anyhow!(msg)})?;
 
-            // Check protocol is valid for provider
-            protocol = requested_protocol
-                .unwrap_or_else(|| provider.get_dyn_provider().default_protocol());
+            // `--provider None` launches an isolated namespace without any VPN
+            // service; it overrides protocol settings from CLI args or the
+            // vopono config file rather than failing the None/None pairing
+            // check below.
+            protocol = if provider == VpnProvider::None {
+                if let Some(requested) = requested_protocol.filter(|p| *p != Protocol::None) {
+                    warn!("Provider None ignores the configured protocol ({requested})");
+                }
+                Protocol::None
+            } else {
+                requested_protocol.unwrap_or_else(|| provider.get_dyn_provider().default_protocol())
+            };
         }
 
         // TODO: Error handling

--- a/src/args_config.rs
+++ b/src/args_config.rs
@@ -109,6 +109,8 @@ pub struct ArgsConfig {
     pub ssh_proxy_port: u16,
     pub ssh_user: Option<String>,
     pub ssh_port: Option<u16>,
+    /// Emit a machine-readable launch report on stdout.
+    pub json: bool,
 }
 
 impl ArgsConfig {
@@ -345,6 +347,8 @@ impl ArgsConfig {
             .or_else(|| config.get("ssh_port").ok())
             .or_else(|| config.get("ssh-port").ok());
 
+        let json = command_else_config_bool!(json, command, config);
+
         // TODO: Group some of these arguments into their own structs
         Ok(Self {
             provider,
@@ -381,6 +385,7 @@ impl ArgsConfig {
             ssh_proxy_port,
             ssh_user,
             ssh_port,
+            json,
         })
     }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,32 +1,84 @@
 //! Namespace connectivity checks.
 //!
 //! The probe runs this same binary inside the target namespace via
-//! `ip netns exec` and performs a single TCP connect, so it works for every
-//! protocol and requires no extra dependencies. It needs root privileges to
-//! enter the namespace: direct calls therefore come from the daemon (or the
-//! sudo fallback path), never from unprivileged callers.
+//! `ip netns exec` and performs three independent checks: a TCP connect over
+//! IPv4, a TCP connect over IPv6, and a DNS resolution using the namespace's
+//! own resolver. Results are reported per family even when siblings fail -
+//! partial health is exactly what makes the probe useful for debugging.
+//!
+//! It needs root privileges to enter the namespace: direct calls therefore
+//! come from the daemon (or the sudo fallback path), never from unprivileged
+//! callers.
+//!
+// NOTE: A port-forwarding check (e.g. verifying that an automatically
+// forwarded port actually accepts connections through the tunnel) could live
+// alongside this probe in the future, but is out of scope for now.
 
 use crate::args::ProbeCommand;
 use anyhow::{Context, anyhow};
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use std::net::{IpAddr, SocketAddr, TcpStream};
-use std::str::FromStr;
 use std::time::{Duration, Instant};
 use vopono_core::util::hostname_to_ip;
 
-pub const DEFAULT_CHECK_HOST: &str = "1.1.1.1";
 pub const DEFAULT_CHECK_PORT: u16 = 443;
-pub const DEFAULT_CHECK_TIMEOUT_MS: u64 = 3000;
+pub const DEFAULT_TIMEOUT_MS: u64 = 3000;
+pub const DEFAULT_V4_HOST: &str = "1.1.1.1";
+pub const DEFAULT_V6_HOST: &str = "2606:4700:4700::1111";
+pub const DEFAULT_DNS_HOST: &str = "one.one.one.one";
+
+/// Reachability of one address family.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FamilyStatus {
+    /// Target that was probed (`ip:port`).
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl FamilyStatus {
+    fn ok(target: &str, latency_ms: u64) -> Self {
+        Self {
+            target: target.to_string(),
+            latency_ms: Some(latency_ms),
+            error: None,
+        }
+    }
+
+    fn failed(target: &str, error: impl Display) -> Self {
+        Self {
+            target: target.to_string(),
+            latency_ms: None,
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DnsStatus {
+    /// Host that was resolved inside the namespace.
+    pub host: String,
+    /// All returned addresses (A and AAAA), in resolver order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub resolved_ips: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConnectivityStatus {
     pub id: String,
+    /// True when at least one checked family passes through the tunnel.
     pub connected: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub latency_ms: Option<u64>,
-    pub target: String,
+    pub ipv4: Option<FamilyStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub ipv6: Option<FamilyStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dns: Option<DnsStatus>,
 }
 
 /// Versioned JSON document for `vopono check`.
@@ -43,89 +95,309 @@ impl ConnectivityStatus {
         } else {
             "no connectivity"
         };
-        let latency = self
-            .latency_ms
-            .map(|ms| format!("{ms}ms"))
-            .unwrap_or_else(|| "-".to_string());
-        format!("{}\t{state}\t{latency}\t{}", self.id, self.target)
+        let mut line = format!("{}\t{}", self.id, state);
+        for (label, family) in [("v4", &self.ipv4), ("v6", &self.ipv6)] {
+            if let Some(family) = family {
+                match family.latency_ms {
+                    Some(ms) => line.push_str(&format!("\t{label} {ms}ms")),
+                    None => line.push_str(&format!(
+                        "\t{label} failed ({})",
+                        family.error.as_deref().unwrap_or("unknown")
+                    )),
+                }
+            }
+        }
+        if let Some(dns) = &self.dns {
+            if dns.resolved_ips.is_empty() {
+                line.push_str("\tdns failed");
+            } else {
+                let latency = dns
+                    .latency_ms
+                    .map(|ms| format!(" {ms}ms"))
+                    .unwrap_or_default();
+                line.push_str(&format!("\tdns {}{}", dns.resolved_ips.join(","), latency));
+            }
+        }
+        line
     }
+}
+
+/// What the child probe prints on stdout for the parent to parse. Families
+/// that were skipped are absent; attempted families are present with either
+/// timings or an error.
+#[derive(Serialize, Deserialize)]
+struct ProbeResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    v4: Option<ChildFamily>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    v6: Option<ChildFamily>,
+    /// Absent entirely when the DNS check was skipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dns_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    dns_addrs: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChildFamily {
+    ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    err: Option<String>,
 }
 
 /// Entry point of the hidden `__connectivity-probe` subcommand.
 ///
-/// Executes inside the target namespace: resolves `host` with the namespace's
-/// own resolver, opens one TCP connection, prints the measured latency in ms
-/// on success and exits non-zero on failure.
+/// Executes inside the target namespace: opens one TCP connection per enabled
+/// family and resolves a hostname through the namespace's own resolver,
+/// printing a JSON summary of every result.
 pub fn run_probe(command: ProbeCommand) -> anyhow::Result<()> {
-    let started = Instant::now();
-    connect(&command.host, command.port, command.timeout_ms)?;
-    println!("{}", started.elapsed().as_millis());
-    Ok(())
-}
-
-fn connect(host: &str, port: u16, timeout_ms: u64) -> anyhow::Result<TcpStream> {
-    let ip = match IpAddr::from_str(host) {
-        Ok(ip) => ip,
-        Err(_) => hostname_to_ip(host)?
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow!("Could not resolve host: {host}"))?,
+    let mut report = ProbeResult {
+        v4: None,
+        v6: None,
+        dns_ms: None,
+        dns_addrs: Vec::new(),
     };
-    TcpStream::connect_timeout(
-        &SocketAddr::new(ip, port),
-        Duration::from_millis(timeout_ms),
-    )
-    .with_context(|| format!("TCP connect to {ip}:{port} failed"))
+    let mut any_success = false;
+
+    if !command.skip_ipv4 {
+        report.v4 = Some(probe_family(
+            command.v4_host.as_deref().unwrap_or(DEFAULT_V4_HOST),
+            command.port,
+            command.timeout_ms,
+            false,
+        ));
+        any_success |= report.v4.as_ref().and_then(|f| f.ms).is_some();
+    }
+    if !command.skip_ipv6 {
+        report.v6 = Some(probe_family(
+            command.v6_host.as_deref().unwrap_or(DEFAULT_V6_HOST),
+            command.port,
+            command.timeout_ms,
+            true,
+        ));
+        any_success |= report.v6.as_ref().and_then(|f| f.ms).is_some();
+    }
+
+    if !command.skip_dns {
+        let dns_host = command.dns_host.as_deref().unwrap_or(DEFAULT_DNS_HOST);
+        let started = Instant::now();
+        // Resolve through the namespace resolver (std uses /etc/netns/<name>
+        // resolv.conf transparently under ip netns exec).
+        report.dns_addrs = resolve_all(dns_host)
+            .map(|ips| ips.iter().map(|ip| ip.to_string()).collect())
+            .unwrap_or_default();
+        if !report.dns_addrs.is_empty() {
+            report.dns_ms = Some(started.elapsed().as_millis() as u64);
+        }
+    }
+
+    println!("{}", serde_json::to_string(&report)?);
+
+    if any_success || (command.skip_ipv4 && command.skip_ipv6) {
+        Ok(())
+    } else {
+        Err(anyhow!("No connectivity through the namespace"))
+    }
 }
 
-/// Probe connectivity of an existing network namespace. Requires root.
-pub fn probe_namespace(id: &str, host: &str, port: u16, timeout_ms: u64) -> ConnectivityStatus {
-    let target = format!("tcp {host}:{port}");
-    match probe_namespace_inner(id, host, port, timeout_ms) {
-        Ok(latency_ms) => ConnectivityStatus {
-            id: id.to_string(),
-            connected: true,
-            latency_ms: Some(latency_ms),
-            target,
-            error: None,
+fn probe_family(host: &str, port: u16, timeout_ms: u64, v6: bool) -> ChildFamily {
+    let started = Instant::now();
+    let attempt = resolve_family(host, v6).and_then(|ip| {
+        TcpStream::connect_timeout(
+            &SocketAddr::new(ip, port),
+            Duration::from_millis(timeout_ms),
+        )
+        .with_context(|| format!("TCP connect to {ip}:{port} failed"))
+    });
+    match attempt {
+        Ok(_) => ChildFamily {
+            ms: Some(started.elapsed().as_millis() as u64),
+            err: None,
         },
-        Err(error) => ConnectivityStatus {
-            id: id.to_string(),
-            connected: false,
-            latency_ms: None,
-            target,
-            error: Some(format!("{error:#}")),
+        Err(error) => ChildFamily {
+            ms: None,
+            err: Some(format!("{error:#}")),
         },
     }
 }
 
-fn probe_namespace_inner(id: &str, host: &str, port: u16, timeout_ms: u64) -> anyhow::Result<u64> {
-    let exe = std::env::current_exe().context("Failed to locate the vopono binary")?;
-    let output = std::process::Command::new("ip")
-        .args(["netns", "exec", id])
-        .arg(&exe)
-        .args([
+fn resolve_all(host: &str) -> anyhow::Result<Vec<IpAddr>> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![ip]);
+    }
+    hostname_to_ip(host)
+}
+
+fn resolve_family(host: &str, v6: bool) -> anyhow::Result<IpAddr> {
+    let ips = resolve_all(host)?;
+    let wanted = ips
+        .into_iter()
+        .find(|ip| ip.is_ipv6() == v6)
+        .ok_or_else(|| anyhow!("No {} address for {host}", if v6 { "IPv6" } else { "IPv4" }))?;
+    Ok(wanted)
+}
+
+/// Probe connectivity of an existing network namespace. Requires root.
+#[allow(clippy::too_many_arguments)]
+pub fn probe_namespace(
+    id: &str,
+    v4_host: &str,
+    v6_host: &str,
+    port: u16,
+    timeout_ms: u64,
+    dns_host: &str,
+    skip_ipv4: bool,
+    skip_ipv6: bool,
+    skip_dns: bool,
+) -> ConnectivityStatus {
+    let outcome = probe_namespace_inner(
+        id, v4_host, v6_host, port, timeout_ms, dns_host, skip_ipv4, skip_ipv6, skip_dns,
+    );
+    let mut status = ConnectivityStatus {
+        id: id.to_string(),
+        connected: false,
+        ipv4: outcome
+            .ipv4
+            .map(|family| family.into_status(&format!("{v4_host}:{port}"))),
+        ipv6: outcome
+            .ipv6
+            .map(|family| family.into_status(&format!("[{v6_host}]:{port}"))),
+        dns: outcome.dns,
+    };
+    status.connected = [&status.ipv4, &status.ipv6]
+        .into_iter()
+        .flatten()
+        .any(|family| family.latency_ms.is_some());
+    status
+}
+
+/// Intermediate view combining the child report with the requested targets.
+struct OutcomeView {
+    ipv4: Option<FamilyOutcome>,
+    ipv6: Option<FamilyOutcome>,
+    dns: Option<DnsStatus>,
+}
+
+struct FamilyOutcome {
+    ms: Option<u64>,
+    err: Option<String>,
+}
+
+impl FamilyOutcome {
+    fn into_status(self, target: &str) -> FamilyStatus {
+        FamilyStatus {
+            target: target.to_string(),
+            latency_ms: self.ms,
+            error: self.err,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn probe_namespace_inner(
+    id: &str,
+    v4_host: &str,
+    v6_host: &str,
+    port: u16,
+    timeout_ms: u64,
+    dns_host: &str,
+    skip_ipv4: bool,
+    skip_ipv6: bool,
+    skip_dns: bool,
+) -> OutcomeView {
+    let exe = std::env::current_exe().context("Failed to locate the vopono binary");
+    let launched = exe.and_then(|exe| {
+        let mut cmd = std::process::Command::new("ip");
+        cmd.args(["netns", "exec", id]).arg(&exe).args([
             "__connectivity-probe",
-            "--host",
-            host,
             "--port",
             &port.to_string(),
             "--timeout-ms",
             &timeout_ms.to_string(),
-        ])
-        .output()
-        .with_context(|| format!("Failed to launch probe inside namespace '{id}'"))?;
+        ]);
+        if !skip_ipv4 {
+            cmd.args(["--v4-host", v4_host]);
+        } else {
+            cmd.arg("--skip-ipv4");
+        }
+        if !skip_ipv6 {
+            cmd.args(["--v6-host", v6_host]);
+        } else {
+            cmd.arg("--skip-ipv6");
+        }
+        if !skip_dns {
+            cmd.args(["--dns-host", dns_host]);
+        } else {
+            cmd.arg("--skip-dns");
+        }
+        cmd.output()
+            .with_context(|| format!("Failed to launch probe inside namespace '{id}'"))
+    });
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Probe in namespace '{id}' failed: {}", stderr.trim());
-    }
+    let output = match launched {
+        Ok(output) => output,
+        Err(error) => {
+            return OutcomeView {
+                ipv4: (!skip_ipv4).then(|| FamilyOutcome::from_error(error)),
+                ipv6: (!skip_ipv6).then(|| FamilyOutcome::from_error("probe did not run")),
+                dns: (!skip_dns).then(|| DnsStatus {
+                    host: dns_host.to_string(),
+                    resolved_ips: Vec::new(),
+                    latency_ms: None,
+                }),
+            };
+        }
+    };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout
-        .trim()
-        .parse::<u64>()
-        .map_err(|_| anyhow!("Probe returned unexpected output: {:?}", stdout.trim()))
+    let parsed: Option<ProbeResult> = serde_json::from_str(stdout.trim()).ok();
+
+    let family_outcome = |child: Option<&ChildFamily>| -> Option<FamilyOutcome> {
+        child.map(|family| FamilyOutcome {
+            ms: family.ms,
+            err: family.err.clone(),
+        })
+    };
+
+    // The parent owns the skip decision: an absent DNS section in the child
+    // report means skipped, not failed.
+    let dns = if skip_dns {
+        None
+    } else {
+        parsed.as_ref().map(|report| DnsStatus {
+            host: dns_host.to_string(),
+            resolved_ips: report.dns_addrs.clone(),
+            latency_ms: report.dns_ms,
+        })
+    };
+
+    if parsed.is_none() {
+        let error = anyhow!(
+            "Probe in namespace '{id}' produced no parsable output: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return OutcomeView {
+            ipv4: (!skip_ipv4).then(|| FamilyOutcome::from_error(error)),
+            ipv6: (!skip_ipv6).then(|| FamilyOutcome::from_error("unavailable")),
+            dns,
+        };
+    }
+
+    let report = parsed.unwrap();
+    OutcomeView {
+        ipv4: family_outcome(report.v4.as_ref()),
+        ipv6: family_outcome(report.v6.as_ref()),
+        dns,
+    }
+}
+
+impl FamilyOutcome {
+    fn from_error(error: impl Display) -> Self {
+        Self {
+            ms: None,
+            err: Some(error.to_string()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -133,27 +405,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn human_line_renders_states() {
-        let ok = ConnectivityStatus {
+    fn parses_child_report_with_both_families() {
+        let raw = r#"{"v4":{"ms":12},"v6":{"ms":20},"dns_ms":3,"dns_addrs":["1.1.1.1","2606:4700:4700::1111"]}"#;
+        let report: ProbeResult = serde_json::from_str(raw).unwrap();
+        assert_eq!(report.v4.unwrap().ms, Some(12));
+        assert_eq!(report.v6.unwrap().ms, Some(20));
+        assert_eq!(report.dns_addrs.len(), 2);
+    }
+
+    #[test]
+    fn parses_child_report_with_failures_and_skips() {
+        let raw = r#"{"v4":{"ms":null,"err":"connect failed"},"dns_ms":null}"#;
+        let report: ProbeResult = serde_json::from_str(raw).unwrap();
+        assert_eq!(report.v4.unwrap().ms, None);
+        assert!(report.v6.is_none(), "skipped families stay absent");
+        assert!(report.dns_addrs.is_empty());
+        assert!(serde_json::from_str::<ProbeResult>("garbage").is_err());
+    }
+
+    #[test]
+    fn human_line_renders_dual_stack_states() {
+        let status = ConnectivityStatus {
             id: "vo_a_r".to_string(),
             connected: true,
-            latency_ms: Some(42),
-            target: "tcp 1.1.1.1:443".to_string(),
-            error: None,
-        };
-        assert_eq!(ok.human_line(), "vo_a_r\tconnected\t42ms\ttcp 1.1.1.1:443");
-
-        let down = ConnectivityStatus {
-            id: "vo_a_r".to_string(),
-            connected: false,
-            latency_ms: None,
-            target: "tcp 1.1.1.1:443".to_string(),
-            error: Some("boom".to_string()),
+            ipv4: Some(FamilyStatus::ok("1.1.1.1:443", 42)),
+            ipv6: Some(FamilyStatus::failed(
+                "[2606:4700:4700::1111]:443",
+                "network unreachable",
+            )),
+            dns: Some(DnsStatus {
+                host: "one.one.one.one".to_string(),
+                resolved_ips: vec!["1.1.1.1".to_string(), "2606:4700:4700::1111".to_string()],
+                latency_ms: Some(7),
+            }),
         };
         assert_eq!(
-            down.human_line(),
-            "vo_a_r\tno connectivity\t-\ttcp 1.1.1.1:443"
+            status.human_line(),
+            "vo_a_r\tconnected\tv4 42ms\tv6 failed (network unreachable)\tdns 1.1.1.1,2606:4700:4700::1111 7ms"
         );
+
+        let disconnected = ConnectivityStatus {
+            id: "vo_a_r".to_string(),
+            connected: false,
+            ipv4: None,
+            ipv6: None,
+            dns: None,
+        };
+        assert_eq!(disconnected.human_line(), "vo_a_r\tno connectivity");
     }
 
     #[test]
@@ -163,14 +461,15 @@ mod tests {
             result: ConnectivityStatus {
                 id: "vo_x".to_string(),
                 connected: false,
-                latency_ms: None,
-                target: "t".to_string(),
-                error: None,
+                ipv4: None,
+                ipv6: None,
+                dns: None,
             },
         };
         let json = serde_json::to_value(&doc).unwrap();
-        assert!(json["result"].get("latency_ms").is_none());
-        assert!(json["result"].get("error").is_none());
+        assert!(json["result"].get("ipv4").is_none());
+        assert!(json["result"].get("ipv6").is_none());
+        assert!(json["result"].get("dns").is_none());
         assert_eq!(json["version"], crate::api::SCHEMA_VERSION);
     }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,176 @@
+//! Namespace connectivity checks.
+//!
+//! The probe runs this same binary inside the target namespace via
+//! `ip netns exec` and performs a single TCP connect, so it works for every
+//! protocol and requires no extra dependencies. It needs root privileges to
+//! enter the namespace: direct calls therefore come from the daemon (or the
+//! sudo fallback path), never from unprivileged callers.
+
+use crate::args::ProbeCommand;
+use anyhow::{Context, anyhow};
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+use vopono_core::util::hostname_to_ip;
+
+pub const DEFAULT_CHECK_HOST: &str = "1.1.1.1";
+pub const DEFAULT_CHECK_PORT: u16 = 443;
+pub const DEFAULT_CHECK_TIMEOUT_MS: u64 = 3000;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConnectivityStatus {
+    pub id: String,
+    pub connected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Versioned JSON document for `vopono check`.
+#[derive(Debug, Serialize)]
+pub struct ConnectivityDocument {
+    pub version: u8,
+    pub result: ConnectivityStatus,
+}
+
+impl ConnectivityStatus {
+    pub fn human_line(&self) -> String {
+        let state = if self.connected {
+            "connected"
+        } else {
+            "no connectivity"
+        };
+        let latency = self
+            .latency_ms
+            .map(|ms| format!("{ms}ms"))
+            .unwrap_or_else(|| "-".to_string());
+        format!("{}\t{state}\t{latency}\t{}", self.id, self.target)
+    }
+}
+
+/// Entry point of the hidden `__connectivity-probe` subcommand.
+///
+/// Executes inside the target namespace: resolves `host` with the namespace's
+/// own resolver, opens one TCP connection, prints the measured latency in ms
+/// on success and exits non-zero on failure.
+pub fn run_probe(command: ProbeCommand) -> anyhow::Result<()> {
+    let started = Instant::now();
+    connect(&command.host, command.port, command.timeout_ms)?;
+    println!("{}", started.elapsed().as_millis());
+    Ok(())
+}
+
+fn connect(host: &str, port: u16, timeout_ms: u64) -> anyhow::Result<TcpStream> {
+    let ip = match IpAddr::from_str(host) {
+        Ok(ip) => ip,
+        Err(_) => hostname_to_ip(host)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("Could not resolve host: {host}"))?,
+    };
+    TcpStream::connect_timeout(
+        &SocketAddr::new(ip, port),
+        Duration::from_millis(timeout_ms),
+    )
+    .with_context(|| format!("TCP connect to {ip}:{port} failed"))
+}
+
+/// Probe connectivity of an existing network namespace. Requires root.
+pub fn probe_namespace(id: &str, host: &str, port: u16, timeout_ms: u64) -> ConnectivityStatus {
+    let target = format!("tcp {host}:{port}");
+    match probe_namespace_inner(id, host, port, timeout_ms) {
+        Ok(latency_ms) => ConnectivityStatus {
+            id: id.to_string(),
+            connected: true,
+            latency_ms: Some(latency_ms),
+            target,
+            error: None,
+        },
+        Err(error) => ConnectivityStatus {
+            id: id.to_string(),
+            connected: false,
+            latency_ms: None,
+            target,
+            error: Some(format!("{error:#}")),
+        },
+    }
+}
+
+fn probe_namespace_inner(id: &str, host: &str, port: u16, timeout_ms: u64) -> anyhow::Result<u64> {
+    let exe = std::env::current_exe().context("Failed to locate the vopono binary")?;
+    let output = std::process::Command::new("ip")
+        .args(["netns", "exec", id])
+        .arg(&exe)
+        .args([
+            "__connectivity-probe",
+            "--host",
+            host,
+            "--port",
+            &port.to_string(),
+            "--timeout-ms",
+            &timeout_ms.to_string(),
+        ])
+        .output()
+        .with_context(|| format!("Failed to launch probe inside namespace '{id}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Probe in namespace '{id}' failed: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| anyhow!("Probe returned unexpected output: {:?}", stdout.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_line_renders_states() {
+        let ok = ConnectivityStatus {
+            id: "vo_a_r".to_string(),
+            connected: true,
+            latency_ms: Some(42),
+            target: "tcp 1.1.1.1:443".to_string(),
+            error: None,
+        };
+        assert_eq!(ok.human_line(), "vo_a_r\tconnected\t42ms\ttcp 1.1.1.1:443");
+
+        let down = ConnectivityStatus {
+            id: "vo_a_r".to_string(),
+            connected: false,
+            latency_ms: None,
+            target: "tcp 1.1.1.1:443".to_string(),
+            error: Some("boom".to_string()),
+        };
+        assert_eq!(
+            down.human_line(),
+            "vo_a_r\tno connectivity\t-\ttcp 1.1.1.1:443"
+        );
+    }
+
+    #[test]
+    fn json_document_omits_absent_fields() {
+        let doc = ConnectivityDocument {
+            version: crate::api::SCHEMA_VERSION,
+            result: ConnectivityStatus {
+                id: "vo_x".to_string(),
+                connected: false,
+                latency_ms: None,
+                target: "t".to_string(),
+                error: None,
+            },
+        };
+        let json = serde_json::to_value(&doc).unwrap();
+        assert!(json["result"].get("latency_ms").is_none());
+        assert!(json["result"].get("error").is_none());
+        assert_eq!(json["version"], crate::api::SCHEMA_VERSION);
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -198,6 +198,8 @@ pub enum DaemonRequest {
     Version,
     /// Lifecycle control executed with the daemon's root privileges.
     Stop(DaemonStopRequest),
+    /// Probe connectivity of an existing network namespace (requires root).
+    CheckNamespace(CheckNamespaceRequest),
 }
 
 #[derive(Serialize, Deserialize, wincode::SchemaWrite, wincode::SchemaRead, Debug, Clone)]
@@ -217,6 +219,14 @@ pub struct DaemonStopRequest {
     /// Client's XDG_CONFIG_HOME so the daemon reads the caller's lockfiles
     /// rather than root's.
     pub config_home: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, wincode::SchemaWrite, wincode::SchemaRead, Debug, Clone)]
+pub struct CheckNamespaceRequest {
+    pub id: String,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub timeout_ms: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, wincode::SchemaWrite, wincode::SchemaRead, Debug)]
@@ -409,7 +419,7 @@ fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
             // other active clients before tearing down the namespace.
             let client_lock_path: Option<PathBuf> =
                 match _ns_guard.write_client_lockfile(child.id(), &requested_application) {
-                    Ok(path) => Some(path),
+                    Ok(path) => path,
                     Err(error) => {
                         log::warn!("Failed to write daemon client status lockfile: {error}");
                         None
@@ -593,6 +603,25 @@ fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
                 Ok(result) => serde_json::to_vec(&result)?,
                 Err(error) => serde_json::to_vec(&crate::errors::error_json_value(&error))?,
             };
+            let bytes = wincode::serialize(&DaemonResponse::Json(payload))?;
+            conn.write_all(&(bytes.len() as u32).to_be_bytes())?;
+            conn.write_all(&bytes)?;
+        }
+        DaemonRequest::CheckNamespace(request) => {
+            // The probe needs root to enter the namespace, so it can only run
+            // here (or in the sudo fallback path of the CLI).
+            let status = crate::check::probe_namespace(
+                &request.id,
+                request
+                    .host
+                    .as_deref()
+                    .unwrap_or(crate::check::DEFAULT_CHECK_HOST),
+                request.port.unwrap_or(crate::check::DEFAULT_CHECK_PORT),
+                request
+                    .timeout_ms
+                    .unwrap_or(crate::check::DEFAULT_CHECK_TIMEOUT_MS),
+            );
+            let payload = serde_json::to_vec(&status)?;
             let bytes = wincode::serialize(&DaemonResponse::Json(payload))?;
             conn.write_all(&(bytes.len() as u32).to_be_bytes())?;
             conn.write_all(&bytes)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -224,9 +224,17 @@ pub struct DaemonStopRequest {
 #[derive(Serialize, Deserialize, wincode::SchemaWrite, wincode::SchemaRead, Debug, Clone)]
 pub struct CheckNamespaceRequest {
     pub id: String,
-    pub host: Option<String>,
     pub port: Option<u16>,
     pub timeout_ms: Option<u64>,
+    /// IPv4 target for the tunnel reachability check.
+    pub v4_host: Option<String>,
+    /// IPv6 target for the tunnel reachability check.
+    pub v6_host: Option<String>,
+    pub skip_ipv4: Option<bool>,
+    pub skip_ipv6: Option<bool>,
+    /// Hostname resolved via the namespace's own DNS configuration.
+    pub dns_host: Option<String>,
+    pub skip_dns: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, wincode::SchemaWrite, wincode::SchemaRead, Debug)]
@@ -613,13 +621,24 @@ fn handle_client(mut conn: LocalSocketStream) -> anyhow::Result<()> {
             let status = crate::check::probe_namespace(
                 &request.id,
                 request
-                    .host
+                    .v4_host
                     .as_deref()
-                    .unwrap_or(crate::check::DEFAULT_CHECK_HOST),
+                    .unwrap_or(crate::check::DEFAULT_V4_HOST),
+                request
+                    .v6_host
+                    .as_deref()
+                    .unwrap_or(crate::check::DEFAULT_V6_HOST),
                 request.port.unwrap_or(crate::check::DEFAULT_CHECK_PORT),
                 request
                     .timeout_ms
-                    .unwrap_or(crate::check::DEFAULT_CHECK_TIMEOUT_MS),
+                    .unwrap_or(crate::check::DEFAULT_TIMEOUT_MS),
+                request
+                    .dns_host
+                    .as_deref()
+                    .unwrap_or(crate::check::DEFAULT_DNS_HOST),
+                request.skip_ipv4.unwrap_or(false),
+                request.skip_ipv6.unwrap_or(false),
+                request.skip_dns.unwrap_or(false),
             );
             let payload = serde_json::to_vec(&status)?;
             let bytes = wincode::serialize(&DaemonResponse::Json(payload))?;

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -9,7 +9,7 @@ use log::{debug, error, info, warn};
 use signal_hook::iterator::SignalsInfo;
 use signal_hook::{consts::SIGINT, iterator::Signals};
 use std::net::{IpAddr, Ipv4Addr};
-use std::os::fd::RawFd;
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::path::PathBuf;
 use std::{
     fs::create_dir_all,
@@ -112,6 +112,16 @@ pub fn execute_as_daemon_with_stdio(
         }
     }
 
+    // Machine-readable launch summary for frontend integrations, written to
+    // the client's stdout before any application output. Take ownership of
+    // the descriptor up-front: ApplicationWrapper hands it to the spawned
+    // child via Stdio::from_raw_fd, which closes it on drop.
+    let report_out: Option<OwnedFd> = if parsed_command.json {
+        stdio_fds.map(|(_, stdout_fd, _)| unsafe { OwnedFd::from_raw_fd(stdout_fd) })
+    } else {
+        None
+    };
+
     let ns = ns.write_lockfile(&parsed_command.application)?;
     let application = ApplicationWrapper::new(
         &ns,
@@ -126,8 +136,29 @@ pub fn execute_as_daemon_with_stdio(
         stdio_fds,
         take_controlling_tty,
     )?;
-    ns.update_lockfile_application_pid(application.handle.id())?;
+    let pid = application.handle.id();
+    ns.update_lockfile_application_pid(pid)?;
+
+    if let Some(report_out) = report_out {
+        let report = launch_report(&ns, pid, application.port_forwarding.as_deref());
+        let mut out = std::fs::File::from(report_out);
+        let _ = writeln!(out, "{report}");
+        let _ = out.flush();
+    }
+
     Ok((application, ns))
+}
+
+/// Single-line machine-readable launch summary for `exec --json`.
+fn launch_report(ns: &NetworkNamespace, pid: u32, forwarder: Option<&dyn Forwarder>) -> String {
+    serde_json::json!({
+        "version": crate::api::SCHEMA_VERSION,
+        "event": "launched",
+        "namespace": ns.name,
+        "pid": pid,
+        "forwarded_port": forwarder.map(|f| f.forwarded_port()),
+    })
+    .to_string()
 }
 
 /// The main entry point for the non-daemon (sudo-based fallback) execution path.
@@ -503,6 +534,14 @@ fn run_application_and_wait(
             "Application {} launched in network namespace {} with pid {}",
             parsed_command.application, ns.name, pid
         );
+
+        if parsed_command.json {
+            println!(
+                "{}",
+                launch_report(ns, pid, application.port_forwarding.as_deref())
+            );
+            io::stdout().flush()?;
+        }
 
         if let Some(fwd) = application.port_forwarding.as_ref() {
             info!("Port Forwarding on port {}", fwd.forwarded_port())

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -2,6 +2,7 @@ use crate::args_config::ArgsConfig;
 use crate::cli_client::CliClient;
 
 use super::args::ExecCommand;
+use super::args::WrappedArg;
 use super::sync::synch;
 use anyhow::{anyhow, bail};
 use log::{debug, error, info, warn};
@@ -162,6 +163,28 @@ fn setup_namespace(
     auto_sync_if_missing: bool,
 ) -> anyhow::Result<NamespaceConfig> {
     create_dir_all(vopono_dir()?)?;
+
+    // Attach mode (`--existing-netns <name>`): reuse a running namespace
+    // as-is. The connection settings are neutralized here, at the CLI layer,
+    // so defaults from the user's vopono config.toml (provider, protocol,
+    // server) cannot trigger config sync or server requirements for a
+    // namespace that already exists. Provider None also satisfies the
+    // provider/protocol pairing validation without bringing up any service.
+    let mut command = command;
+    let mut foreign_attach = false;
+    if let Some(netns) = command.existing_netns.clone() {
+        ensure_namespace_exists(&netns)?;
+        // A lockfile means vopono created this namespace and owns its
+        // lifecycle; anything else is attached untouched.
+        foreign_attach = !vopono_core::status::read_lock_namespaces()?
+            .namespaces
+            .contains_key(&netns);
+        info!("Attaching to existing network namespace: {netns}");
+        command.custom_netns_name = Some(netns);
+        command.provider = Some(WrappedArg::new(VpnProvider::None));
+        command.protocol = Some(WrappedArg::new(Protocol::None));
+    }
+
     let vopono_config_settings = ArgsConfig::get_config_file(&command)?;
     let mut host_env_vars = vopono_core::util::env_vars::get_host_env_vars();
 
@@ -234,6 +257,20 @@ fn setup_namespace(
     let forwarder;
 
     if get_existing_namespaces()?.contains(&ns_name) {
+        if foreign_attach {
+            info!(
+                "Attaching to unmanaged namespace {} - vopono will not modify it and will leave it running on exit",
+                ns_name
+            );
+            ns = NetworkNamespace::attach_unmanaged(ns_name)?;
+            forwarder = None;
+            return Ok(NamespaceConfig {
+                ns,
+                parsed_command,
+                forwarder,
+                host_env_vars,
+            });
+        }
         info!(
             "Using existing namespace: {}, will not modify firewall rules",
             ns_name
@@ -525,6 +562,17 @@ fn stay_alive(pid: Option<u32>, mut signals: Signals) {
     receiver.recv().unwrap();
     handle.close();
     thread.join().unwrap();
+}
+
+/// Verify a namespace exists before attaching to it.
+fn ensure_namespace_exists(name: &str) -> anyhow::Result<()> {
+    let existing = get_existing_namespaces()?;
+    if !existing.iter().any(|ns| ns == name) {
+        bail!(
+            "Network namespace '{name}' does not exist - nothing to attach to. Active namespaces: {existing:?}"
+        );
+    }
+    Ok(())
 }
 
 fn run_protocol_in_netns(

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,16 +211,36 @@ fn handle_result(result: anyhow::Result<()>, json: bool) -> anyhow::Result<()> {
 /// Connectivity check: prefer the running root daemon (unprivileged callers
 /// cannot enter a namespace themselves), fall back to sudo like `exec`.
 fn handle_check(command: args::CheckCommand, askpass: bool) -> anyhow::Result<()> {
-    let host = command
-        .host
+    let v4_host = command
+        .v4_host
         .clone()
-        .unwrap_or_else(|| check::DEFAULT_CHECK_HOST.to_string());
-    let local = || check::probe_namespace(&command.id, &host, command.port, command.timeout_ms);
+        .unwrap_or_else(|| check::DEFAULT_V4_HOST.to_string());
+    let v6_host = command
+        .v6_host
+        .clone()
+        .unwrap_or_else(|| check::DEFAULT_V6_HOST.to_string());
+    let dns_host = command
+        .dns_host
+        .clone()
+        .unwrap_or_else(|| check::DEFAULT_DNS_HOST.to_string());
+    let local = || {
+        check::probe_namespace(
+            &command.id,
+            &v4_host,
+            &v6_host,
+            command.port,
+            command.timeout_ms,
+            &dns_host,
+            command.skip_ipv4,
+            command.skip_ipv6,
+            command.skip_dns,
+        )
+    };
 
     let status = if nix::unistd::getuid().is_root() {
         local()
     } else {
-        match forward_check_to_daemon(&command, &host) {
+        match forward_check_to_daemon(&command, &v4_host, &v6_host, &dns_host) {
             Ok(status) => status,
             Err(forward_error) => {
                 info!("Falling back to sudo (daemon check forward failed): {forward_error}");
@@ -247,7 +267,9 @@ fn handle_check(command: args::CheckCommand, askpass: bool) -> anyhow::Result<()
 /// daemon-side failures are reported as a disconnected result.
 fn forward_check_to_daemon(
     command: &args::CheckCommand,
-    host: &str,
+    v4_host: &str,
+    v6_host: &str,
+    dns_host: &str,
 ) -> anyhow::Result<check::ConnectivityStatus> {
     let name = SOCKET_PATH.to_fs_name::<FilesystemUdSocket>()?;
     let mut conn =
@@ -256,9 +278,14 @@ fn forward_check_to_daemon(
 
     let request = daemon::DaemonRequest::CheckNamespace(daemon::CheckNamespaceRequest {
         id: command.id.clone(),
-        host: Some(host.to_string()),
         port: Some(command.port),
         timeout_ms: Some(command.timeout_ms),
+        v4_host: Some(v4_host.to_string()),
+        v6_host: Some(v6_host.to_string()),
+        skip_ipv4: Some(command.skip_ipv4),
+        skip_ipv6: Some(command.skip_ipv6),
+        dns_host: Some(dns_host.to_string()),
+        skip_dns: Some(command.skip_dns),
     });
     let bytes = wincode::serialize(&request)?;
     daemon::write_framed(&mut conn, &bytes)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod api;
 mod args;
 mod args_config;
+mod check;
 mod cli_client;
 mod control;
 mod daemon;
@@ -111,6 +112,14 @@ fn main() -> anyhow::Result<()> {
         args::Command::Status(status) => {
             handle_result(output_status(status.json), status.json)?;
         }
+        args::Command::Check(check) => {
+            handle_check(check, app.askpass)?;
+        }
+        args::Command::Probe(probe) => {
+            // Hidden helper: always runs in-place (the daemon launches it
+            // inside the target namespace); never forward or escalate.
+            check::run_probe(probe)?;
+        }
         args::Command::Providers(providerscmd) => {
             handle_result(
                 providers::print_providers(providerscmd.json),
@@ -196,6 +205,69 @@ fn handle_result(result: anyhow::Result<()>, json: bool) -> anyhow::Result<()> {
             std::process::exit(1);
         }
         Err(error) => Err(error),
+    }
+}
+
+/// Connectivity check: prefer the running root daemon (unprivileged callers
+/// cannot enter a namespace themselves), fall back to sudo like `exec`.
+fn handle_check(command: args::CheckCommand, askpass: bool) -> anyhow::Result<()> {
+    let host = command
+        .host
+        .clone()
+        .unwrap_or_else(|| check::DEFAULT_CHECK_HOST.to_string());
+    let local = || check::probe_namespace(&command.id, &host, command.port, command.timeout_ms);
+
+    let status = if nix::unistd::getuid().is_root() {
+        local()
+    } else {
+        match forward_check_to_daemon(&command, &host) {
+            Ok(status) => status,
+            Err(forward_error) => {
+                info!("Falling back to sudo (daemon check forward failed): {forward_error}");
+                clean_dead_locks()?;
+                elevate_privileges(askpass)?;
+                local()
+            }
+        }
+    };
+
+    if command.json {
+        api::print_json(&check::ConnectivityDocument {
+            version: api::SCHEMA_VERSION,
+            result: status,
+        })?;
+    } else {
+        println!("{}", status.human_line());
+    }
+    Ok(())
+}
+
+/// Route a connectivity check through the root daemon over `/run/vopono.sock`.
+/// Returns `Err` when the daemon is unreachable so the caller can fall back;
+/// daemon-side failures are reported as a disconnected result.
+fn forward_check_to_daemon(
+    command: &args::CheckCommand,
+    host: &str,
+) -> anyhow::Result<check::ConnectivityStatus> {
+    let name = SOCKET_PATH.to_fs_name::<FilesystemUdSocket>()?;
+    let mut conn =
+        LocalSocketStream::connect(name).map_err(|e| anyhow!("Daemon not running: {e}"))?;
+    daemon::set_socket_timeouts_for(&conn, daemon::DAEMON_STOP_TIMEOUT_SECONDS)?;
+
+    let request = daemon::DaemonRequest::CheckNamespace(daemon::CheckNamespaceRequest {
+        id: command.id.clone(),
+        host: Some(host.to_string()),
+        port: Some(command.port),
+        timeout_ms: Some(command.timeout_ms),
+    });
+    let bytes = wincode::serialize(&request)?;
+    daemon::write_framed(&mut conn, &bytes)?;
+
+    let response_bytes = daemon::read_framed(&mut conn, daemon::MAX_FRAME_LEN)?;
+    match wincode::deserialize::<daemon::DaemonResponse>(&response_bytes)? {
+        daemon::DaemonResponse::Json(payload) => Ok(serde_json::from_slice(&payload)?),
+        daemon::DaemonResponse::Error(message) => Err(anyhow!("Daemon reported: {message}")),
+        _ => Err(anyhow!("Unexpected daemon response to check request")),
     }
 }
 

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs::{File, create_dir_all};
+use std::fs::{self, File, create_dir_all};
 use strum::IntoEnumIterator;
 use vopono_core::config::providers::VpnProvider;
 use vopono_core::config::vpn::Protocol;
@@ -17,6 +17,9 @@ pub struct ProviderInfo {
     pub requires_auth: bool,
     pub port_forwarding: bool,
     pub port_forwarding_automatic: bool,
+    /// Port forwarding availability per protocol id (e.g. `wireguard` ->
+    /// true, `openvpn` -> false for AzireVPN).
+    pub port_forwarding_by_protocol: BTreeMap<String, bool>,
     pub configured: bool,
     pub last_sync: Option<String>,
     pub server_count: usize,
@@ -27,6 +30,8 @@ pub struct ProviderProtocolInfo {
     pub configured: bool,
     pub last_sync: Option<String>,
     pub server_count: usize,
+    /// Whether port forwarding is available over this protocol.
+    pub port_forwarding: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -68,8 +73,14 @@ pub fn print_providers(json: bool) -> anyhow::Result<()> {
         "id\tname\tprotocols\tconfigured\tlast_sync\tport_forwarding\tautomatic_port_forwarding\tserver_count"
     );
     for provider in providers {
+        let pf_by_protocol = provider
+            .port_forwarding_by_protocol
+            .iter()
+            .map(|(protocol, supported)| format!("{protocol}:{supported}"))
+            .collect::<Vec<_>>()
+            .join(",");
         println!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             provider.id,
             provider.name,
             provider.protocols.join(","),
@@ -77,6 +88,7 @@ pub fn print_providers(json: bool) -> anyhow::Result<()> {
             provider.last_sync.as_deref().unwrap_or("never"),
             provider.port_forwarding,
             provider.port_forwarding_automatic,
+            pf_by_protocol,
             provider.server_count
         );
     }
@@ -114,7 +126,7 @@ pub fn provider_status(provider: VpnProvider) -> anyhow::Result<ProviderStatus> 
     let mut protocol_status = BTreeMap::new();
     for protocol in provider.supported_sync_protocols() {
         let id = protocol.id().to_string();
-        let server_count = config_count(&provider, protocol)?;
+        let server_count = config_count(&provider, protocol.clone())?;
         let metadata_entry = metadata
             .as_ref()
             .and_then(|metadata| metadata.protocols.get(&id));
@@ -124,6 +136,7 @@ pub fn provider_status(provider: VpnProvider) -> anyhow::Result<ProviderStatus> 
                 configured: server_count > 0,
                 last_sync: metadata_entry.map(|entry| entry.last_sync.clone()),
                 server_count,
+                port_forwarding: provider.port_forwarding_for(protocol.clone()),
             },
         );
     }
@@ -173,6 +186,15 @@ pub fn provider_info(provider: &VpnProvider) -> anyhow::Result<ProviderInfo> {
         requires_auth: sync_supported,
         port_forwarding: provider.supports_port_forwarding(),
         port_forwarding_automatic: provider.has_automatic_port_forwarding(),
+        port_forwarding_by_protocol: protocols
+            .iter()
+            .map(|protocol| {
+                (
+                    protocol.id().to_string(),
+                    provider.port_forwarding_for(protocol.clone()),
+                )
+            })
+            .collect(),
         configured: server_count > 0,
         last_sync,
         server_count,
@@ -191,12 +213,23 @@ pub fn record_sync(provider: &VpnProvider, protocol: Protocol) -> anyhow::Result
     metadata.protocols.insert(
         protocol.id().to_string(),
         SyncProtocolMetadata {
-            last_sync: timestamp,
-            server_count: config_count(provider, protocol)?,
+            last_sync: timestamp.clone(),
+            server_count: config_count(provider, protocol.clone())?,
         },
     );
     let file = File::create(metadata_path)?;
     serde_json::to_writer_pretty(file, &metadata)?;
+
+    // Global completion stamp so frontends can watch a single file (with e.g.
+    // a FileView) instead of polling `providers --json` for new configs.
+    let stamp = serde_json::json!({
+        "timestamp": timestamp,
+        "provider": provider.id(),
+        "protocol": protocol.id().to_string(),
+    });
+    let stamp_path = vopono_core::util::vopono_dir()?.join(".last-sync");
+    fs::write(&stamp_path, serde_json::to_vec_pretty(&stamp)?)
+        .with_context(|| format!("Failed to write sync stamp {}", stamp_path.display()))?;
     Ok(())
 }
 
@@ -252,9 +285,60 @@ mod tests {
             airvpn.protocols,
             vec!["openvpn".to_string(), "wireguard".to_string()]
         );
+        // AirVPN forwards manually and protocol-independently.
+        assert_eq!(
+            airvpn.port_forwarding_by_protocol,
+            BTreeMap::from([
+                ("openvpn".to_string(), true),
+                ("wireguard".to_string(), true)
+            ])
+        );
 
         let mullvad = provider_info(&VpnProvider::Mullvad).unwrap();
         assert!(!mullvad.port_forwarding);
         assert_eq!(mullvad.protocols, vec!["wireguard".to_string()]);
+        assert_eq!(
+            mullvad.port_forwarding_by_protocol,
+            BTreeMap::from([("wireguard".to_string(), false)])
+        );
+    }
+
+    #[test]
+    fn port_forwarding_matrix_reflects_protocol_support() {
+        use vopono_core::config::vpn::Protocol;
+        // AzireVPN's forwarder only implements the Wireguard flow.
+        assert!(VpnProvider::AzireVPN.port_forwarding_for(Protocol::Wireguard));
+        assert!(!VpnProvider::AzireVPN.port_forwarding_for(Protocol::OpenVpn));
+        // PIA and ProtonVPN forwarders are tunnel-agnostic.
+        for provider in [VpnProvider::PrivateInternetAccess, VpnProvider::ProtonVPN] {
+            assert!(provider.port_forwarding_for(Protocol::Wireguard));
+            assert!(provider.port_forwarding_for(Protocol::OpenVpn));
+        }
+        assert!(!VpnProvider::Mullvad.port_forwarding_for(Protocol::Wireguard));
+    }
+
+    #[test]
+    fn sync_writes_global_completion_stamp() {
+        let dir = std::env::temp_dir().join(format!(
+            "vopono-sync-stamp-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        vopono_core::util::set_config_dir_override(Some(dir.clone()));
+
+        let result = record_sync(&VpnProvider::AirVPN, Protocol::Wireguard);
+        vopono_core::util::set_config_dir_override(None);
+        result.unwrap();
+
+        let stamp_path = dir.join("vopono").join(".last-sync");
+        let stamp: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(stamp_path).unwrap()).unwrap();
+        assert_eq!(stamp["provider"], "airvpn");
+        assert_eq!(stamp["protocol"], "wireguard");
+        assert!(stamp["timestamp"].is_string());
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/vopono_core/src/config/providers/mod.rs
+++ b/vopono_core/src/config/providers/mod.rs
@@ -127,6 +127,20 @@ impl VpnProvider {
         )
     }
 
+    /// Whether port forwarding is available for this provider when using the
+    /// given protocol. PIA and ProtonVPN forwarders are tunnel-agnostic;
+    /// AzireVPN only implements its flow over Wireguard. AirVPN exposes
+    /// manually configured forwarded ports regardless of protocol.
+    pub fn port_forwarding_for(&self, protocol: Protocol) -> bool {
+        if !self.supports_port_forwarding() {
+            return false;
+        }
+        match self {
+            Self::AzireVPN => matches!(protocol, Protocol::Wireguard),
+            _ => true,
+        }
+    }
+
     pub fn get_dyn_provider(&self) -> Box<dyn Provider> {
         match self {
             Self::PrivateInternetAccess => Box::new(pia::PrivateInternetAccess {}),

--- a/vopono_core/src/network/netns.rs
+++ b/vopono_core/src/network/netns.rs
@@ -58,6 +58,11 @@ pub struct NetworkNamespace {
     /// Runtime state shared with the status/lockfile projections.
     #[serde(default)]
     pub state: NamespaceState,
+    /// True when this handle wraps a namespace that was not created by vopono
+    /// (attached via `--existing-netns`). Such namespaces are never modified,
+    /// lockfile-tracked or torn down on drop.
+    #[serde(default)]
+    pub unmanaged: bool,
 }
 
 /// Server/port metadata mirrored into the lockfiles so read-only commands can
@@ -165,6 +170,44 @@ impl NetworkNamespace {
         }
     }
 
+    /// Wrap an already-running network namespace that was not created by
+    /// vopono. The caller must have verified the namespace exists.
+    ///
+    /// Unlike [`Self::from_existing`] this never inspects or writes lockfiles,
+    /// and [`Drop`] leaves the namespace and its firewall configuration
+    /// untouched - its lifecycle belongs to whoever created it.
+    pub fn attach_unmanaged(name: String) -> anyhow::Result<Self> {
+        info!(
+            "Attaching to existing unmanaged network namespace: {}",
+            name
+        );
+        Ok(Self {
+            name,
+            veth_pair: None,
+            dns_config: None,
+            openvpn: None,
+            wireguard: None,
+            host_masquerade: None,
+            firewall_exception: None,
+            shadowsocks: None,
+            ssh: None,
+            veth_pair_ips: None,
+            openconnect: None,
+            openfortivpn: None,
+            warp: None,
+            provider: VpnProvider::None,
+            protocol: Protocol::None,
+            firewall: Firewall::IpTables,
+            predown: None,
+            predown_user: None,
+            predown_group: None,
+            config_file: None,
+            trojan: None,
+            state: NamespaceState::default(),
+            unmanaged: true,
+        })
+    }
+
     pub fn new(
         name: String,
         provider: VpnProvider,
@@ -201,6 +244,7 @@ impl NetworkNamespace {
             config_file: None,
             trojan: None,
             state: NamespaceState::default(),
+            unmanaged: false,
         })
     }
 
@@ -804,6 +848,10 @@ impl NetworkNamespace {
     }
 
     pub fn write_lockfile(self, command: &str) -> anyhow::Result<Self> {
+        if self.unmanaged {
+            // Unmanaged namespaces are not vopono's to track or clean up.
+            return Ok(self);
+        }
         let mut lockfile_path = config_dir()?;
         lockfile_path.push(format!("vopono/locks/{}", self.name));
         std::fs::create_dir_all(&lockfile_path)?;
@@ -834,6 +882,9 @@ impl NetworkNamespace {
     /// Best-effort: a missing lockfile is logged and ignored so daemon startup
     /// is not aborted by an already-torn-down namespace entry.
     pub fn update_lockfile_application_pid(&self, pid: u32) -> anyhow::Result<()> {
+        if self.unmanaged {
+            return Ok(());
+        }
         let mut lockfile_path = config_dir()?;
         lockfile_path.push(format!("vopono/locks/{}/{}", self.name, unistd::getpid()));
         if !lockfile_path.exists() {
@@ -886,7 +937,15 @@ impl NetworkNamespace {
         Ok(())
     }
 
-    pub fn write_client_lockfile(&self, pid: u32, command: &str) -> anyhow::Result<PathBuf> {
+    pub fn write_client_lockfile(
+        &self,
+        pid: u32,
+        command: &str,
+    ) -> anyhow::Result<Option<PathBuf>> {
+        if self.unmanaged {
+            // Unmanaged namespaces are not vopono's to track or clean up.
+            return Ok(None);
+        }
         let mut lockfile_path = config_dir()?;
         lockfile_path.push(format!("vopono/locks/{}", self.name));
         std::fs::create_dir_all(&lockfile_path)?;
@@ -914,7 +973,7 @@ impl NetworkNamespace {
         debug!("Client lockfile written: {}", lockfile_path.display());
 
         set_config_permissions()?;
-        Ok(lockfile_path)
+        Ok(Some(lockfile_path))
     }
 
     pub fn setup_nftables_firewall(&self) -> anyhow::Result<()> {
@@ -971,6 +1030,13 @@ impl NetworkNamespace {
 
 impl Drop for NetworkNamespace {
     fn drop(&mut self) {
+        if self.unmanaged {
+            debug!(
+                "Namespace {} is not managed by vopono - leaving it untouched",
+                self.name
+            );
+            return;
+        }
         let mut lock_dir = config_dir().expect("Failed to get config dir");
         lock_dir.push(format!("vopono/locks/{}", self.name));
         let mut lockfile_path = lock_dir.clone();

--- a/vopono_core/src/network/port_forwarding/mod.rs
+++ b/vopono_core/src/network/port_forwarding/mod.rs
@@ -15,6 +15,10 @@ pub trait ThreadParameters {
     fn get_callback_command(&self) -> Option<String>;
     fn get_loop_delay(&self) -> u64;
     fn get_netns_name(&self) -> String;
+    /// Resolved vopono locks directory. Captured on the creating thread
+    /// because the config-dir override is thread-local and background
+    /// refresh threads would otherwise resolve the wrong root.
+    fn get_locks_dir(&self) -> std::path::PathBuf;
 }
 
 pub trait ThreadLoopForwarder: Forwarder {
@@ -40,6 +44,15 @@ pub trait ThreadLoopForwarder: Forwarder {
                     }
                     Ok(p) => {
                         log::debug!("Thread refreshed port: {p}");
+                        // Keep the lockfile-visible status in sync so status
+                        // readers see the renewed port, not the initial one.
+                        if let Err(e) = crate::status::record_forwarded_port(
+                            &params.get_locks_dir(),
+                            &params.get_netns_name(),
+                            p,
+                        ) {
+                            log::warn!("Failed to update forwarded port status: {e:?}");
+                        }
                         Self::callback_command(&params, p);
                     }
                 }

--- a/vopono_core/src/network/port_forwarding/natpmpc.rs
+++ b/vopono_core/src/network/port_forwarding/natpmpc.rs
@@ -22,6 +22,7 @@ pub struct Natpmpc {
 
 pub struct ThreadParamsImpl {
     pub netns_name: String,
+    pub locks_dir: std::path::PathBuf,
     pub callback: Option<String>,
 }
 
@@ -34,6 +35,9 @@ impl ThreadParameters for ThreadParamsImpl {
     }
     fn get_netns_name(&self) -> String {
         self.netns_name.clone()
+    }
+    fn get_locks_dir(&self) -> std::path::PathBuf {
+        self.locks_dir.clone()
     }
 }
 
@@ -110,6 +114,7 @@ impl Natpmpc {
 
         let params = ThreadParamsImpl {
             netns_name: ns.name.clone(),
+            locks_dir: crate::util::config_dir()?.join("vopono").join("locks"),
             callback: callback.cloned(),
         };
 

--- a/vopono_core/src/network/port_forwarding/piapf.rs
+++ b/vopono_core/src/network/port_forwarding/piapf.rs
@@ -21,6 +21,7 @@ pub struct Piapf {
 pub struct ThreadParamsImpl {
     pub port: u16,
     pub netns_name: String,
+    pub locks_dir: std::path::PathBuf,
     pub signature: String,
     pub payload: String,
     pub hostname: String,
@@ -40,6 +41,10 @@ impl ThreadParameters for ThreadParamsImpl {
 
     fn get_netns_name(&self) -> String {
         self.netns_name.clone()
+    }
+
+    fn get_locks_dir(&self) -> std::path::PathBuf {
+        self.locks_dir.clone()
     }
 }
 
@@ -167,6 +172,7 @@ impl Piapf {
 
         let params = ThreadParamsImpl {
             netns_name: ns.name.clone(),
+            locks_dir: crate::util::config_dir()?.join("vopono").join("locks"),
             hostname: vpn_hostname,
             gateway: vpn_gateway,
             pia_cert_path,

--- a/vopono_core/src/status.rs
+++ b/vopono_core/src/status.rs
@@ -1,10 +1,63 @@
 use crate::network::netns::LockfileStatus;
 use crate::util::config_dir;
 use log::debug;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use walkdir::WalkDir;
+
+/// Sidecar file next to a namespace's lockfiles holding the latest
+/// provider-assigned forwarded port, refreshed by the forwarder thread.
+const FORWARDED_PORT_SIDECAR: &str = "port-forwarding.json";
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ForwardedPortSidecar {
+    port: u16,
+    updated: u64,
+}
+
+/// Record the latest provider-assigned forwarded port for a namespace.
+///
+/// Written to a sidecar file rather than by rewriting the RON lockfile:
+/// primary lockfiles embed namespace handles that must never be deserialized
+/// on background threads (dropping such a copy would tear down the live
+/// namespace).
+pub fn record_forwarded_port(locks_dir: &Path, ns_name: &str, port: u16) -> anyhow::Result<()> {
+    let updated = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let sidecar = ForwardedPortSidecar { port, updated };
+    let dir = locks_dir.join(ns_name);
+    std::fs::create_dir_all(&dir)?;
+    let tmp = dir.join(format!("{FORWARDED_PORT_SIDECAR}.tmp"));
+    let path = dir.join(FORWARDED_PORT_SIDECAR);
+    std::fs::write(&tmp, serde_json::to_vec(&sidecar)?)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Replace the reported forwarded port with the sidecar value when present.
+/// Provider and automatic flag still come from the embedded lockfile state.
+fn overlay_forwarded_port(locks_root: &Path, ns_name: &str, locks: &mut [LockfileStatus]) {
+    let Ok(raw) = std::fs::read(locks_root.join(ns_name).join(FORWARDED_PORT_SIDECAR)) else {
+        return;
+    };
+    let Ok(sidecar) = serde_json::from_slice::<ForwardedPortSidecar>(&raw) else {
+        debug!("Ignoring malformed forwarded-port sidecar for {ns_name}");
+        return;
+    };
+    for lock in locks.iter_mut() {
+        if let Some(status) = lock.ns.state.port_forwarding.as_mut()
+            && status.port != sidecar.port
+        {
+            debug!(
+                "Forwarded port for {ns_name} renewed: {} -> {}",
+                status.port, sidecar.port
+            );
+            status.port = sidecar.port;
+        }
+    }
+}
 
 pub type LockNamespaces = HashMap<String, Vec<LockfileStatus>>;
 
@@ -54,7 +107,7 @@ pub fn read_lock_namespaces_from_dir(
         return Ok(LockNamespacesStatus::default());
     }
 
-    for entry in WalkDir::new(dir) {
+    for entry in WalkDir::new(&dir) {
         let entry = match entry {
             Ok(entry) => entry,
             Err(error) => {
@@ -107,6 +160,13 @@ pub fn read_lock_namespaces_from_dir(
                 errors.push(format!("{}: {error}", entry.path().display()));
             }
         }
+    }
+
+    // Forwarder renewals update the sidecar, not the RON lockfiles, so
+    // reflect the latest forwarded port in every derived view.
+    for (namespace, locks) in grouped_locks.iter_mut() {
+        overlay_forwarded_port(&dir, namespace, &mut locks.primary);
+        overlay_forwarded_port(&dir, namespace, &mut locks.client);
     }
 
     Ok(LockNamespacesStatus {
@@ -236,6 +296,72 @@ mod tests {
         assert_eq!(client_pid_from_lockfile_name("client-4242"), Some(4242));
         assert_eq!(client_pid_from_lockfile_name("client-pid"), None);
         assert_eq!(client_pid_from_lockfile_name("12345"), None);
+    }
+
+    fn forwarding_lock(namespace: &str, port: u16) -> String {
+        format!(
+            r#"(ns:(name:"{namespace}",provider:ProtonVPN,protocol:Wireguard,state:(port_forwarding:Some((provider:ProtonVPN,port:{port},automatic:true)))),start:1,command:"curl")"#
+        )
+    }
+
+    #[test]
+    fn forwarded_port_sidecar_overlays_renewed_port() {
+        let dir = unique_temp_dir("forwarded-port");
+        let ns_dir = dir.join("vo_p_se");
+        fs::create_dir_all(&ns_dir).unwrap();
+        fs::write(ns_dir.join("100"), forwarding_lock("vo_p_se", 1111)).unwrap();
+
+        // No sidecar yet: the embedded port is reported as-is.
+        let status = read_lock_namespaces_from_dir(&dir).unwrap();
+        assert_eq!(
+            status.namespaces["vo_p_se"][0]
+                .ns
+                .state
+                .port_forwarding
+                .as_ref()
+                .unwrap()
+                .port,
+            1111
+        );
+
+        record_forwarded_port(&dir, "vo_p_se", 2222).unwrap();
+        let status = read_lock_namespaces_from_dir(&dir).unwrap();
+        let forwarding = status.namespaces["vo_p_se"][0]
+            .ns
+            .state
+            .port_forwarding
+            .as_ref()
+            .unwrap();
+        assert_eq!(forwarding.port, 2222);
+        // Provider/automatic still come from the lockfile state.
+        assert_eq!(forwarding.provider, VpnProvider::ProtonVPN);
+        assert!(forwarding.automatic);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn malformed_forwarded_port_sidecar_is_ignored() {
+        let dir = unique_temp_dir("forwarded-port-bad");
+        let ns_dir = dir.join("vo_p_se");
+        fs::create_dir_all(&ns_dir).unwrap();
+        fs::write(ns_dir.join("100"), forwarding_lock("vo_p_se", 1111)).unwrap();
+        fs::write(ns_dir.join("port-forwarding.json"), "not json").unwrap();
+
+        let status = read_lock_namespaces_from_dir(&dir).unwrap();
+        assert_eq!(
+            status.namespaces["vo_p_se"][0]
+                .ns
+                .state
+                .port_forwarding
+                .as_ref()
+                .unwrap()
+                .port,
+            1111
+        );
+        assert!(status.errors.is_empty());
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]


### PR DESCRIPTION
- Add `vopono check <netns>`: probes connectivity by running a hidden in-namespace TCP probe via `ip netns exec`. Exposed over the daemon socket as CheckNamespace so unprivileged clients (e.g. the quickshell plugin) can query it; falls back to sudo when no daemon runs. Emits human or versioned JSON output with latency and target.
- Add `exec --existing-netns <name>` to launch applications in a running namespace without repeating provider/protocol/server settings, which conflict with the flag. Vopono-managed namespaces are reused as-is; foreign namespaces attach through the new unmanaged handle that never writes lockfiles and leaves the namespace running on exit.
- Neutralize provider/protocol/server at the CLI layer before merging so defaults from vopono config.toml cannot trigger config sync or server requirements during attach.
- Make `--provider None` self-sufficient: it now overrides protocol and server settings from CLI/config instead of erroring or panicking on the missing default protocol.