### PR TITLE
Update handling for AzireVPN port forwarding not found responses

### DIFF
--- a/vopono_core/src/network/port_forwarding/azirevpn.rs
+++ b/vopono_core/src/network/port_forwarding/azirevpn.rs
@@ -176,7 +176,7 @@ fn parse_success_response<T: DeserializeOwned>(
 }
 
 fn is_not_found_response(error: &anyhow::Error) -> bool {
-    error.to_string().to_ascii_lowercase().contains("not found")
+    error.to_string().to_ascii_lowercase().contains("no port forwardings found")
 }
 
 impl AzireVpnPortForwarding {

--- a/vopono_core/src/network/port_forwarding/azirevpn.rs
+++ b/vopono_core/src/network/port_forwarding/azirevpn.rs
@@ -176,7 +176,10 @@ fn parse_success_response<T: DeserializeOwned>(
 }
 
 fn is_not_found_response(error: &anyhow::Error) -> bool {
-    error.to_string().to_ascii_lowercase().contains("no port forwardings found")
+    error
+        .to_string()
+        .to_ascii_lowercase()
+        .contains("no port forwardings found")
 }
 
 impl AzireVpnPortForwarding {

--- a/vopono_core/src/network/port_forwarding/azirevpn.rs
+++ b/vopono_core/src/network/port_forwarding/azirevpn.rs
@@ -376,7 +376,7 @@ mod tests {
     fn not_found_response_can_be_treated_as_empty_list() {
         let err = parse_success_response::<ListResponse>(
             "list",
-            r#"{"status":"error","message":"Not found"}"#,
+            r#"{"status":"error","message":"No port forwardings found"}"#,
         )
         .unwrap_err();
 


### PR DESCRIPTION
Due to changes in the AzireVPN port forwarding API, the response string for a not found status has changed

Compiles and fixes #377

```
$ ./temp/vopono/cf-git/vopono/target/debug/vopono exec --provider azirevpn --port-forwarding --server sweden-se-got bash
net.ipv6.conf.vo_az_Acp45tv_d.disable_ipv6 = 0
chris@facet:~$ curl ipinfo.io
{
  "ip": "193.187.90.227",
  "city": "Gothenburg",
  "region": "Västra Götaland",
  "country": "SE",
  "loc": "57.7072,11.9668",
  "org": "AS42675 Obehosting AB",
  "postal": "400 10",
  "timezone": "Europe/Stockholm",
  "readme": "https://ipinfo.io/missingauth"
$ #success
```